### PR TITLE
Update UserDbRequest models

### DIFF
--- a/neon_data_models/enum.py
+++ b/neon_data_models/enum.py
@@ -38,8 +38,6 @@ class AccessRoles(IntEnum):
     Special Roles:
         NODE: Reserved for use by a Node device service account to access
             various services
-        RW_USERS: Reserved for use by service accounts to access and modify the
-            users database
     """
     NONE = 0
     # 1-9 reserved for unauthenticated connections
@@ -55,7 +53,6 @@ class AccessRoles(IntEnum):
     # 50 Reserved for "unlimited access"
 
     NODE = -1
-    RW_USERS = -2
 
 
 class UserData(IntEnum):

--- a/neon_data_models/enum.py
+++ b/neon_data_models/enum.py
@@ -49,6 +49,7 @@ class AccessRoles(IntEnum):
     # 50 Reserved for "unlimited access"
 
     NODE = -1
+    READ_USERS = -2, "Used by service accounts to read users from the database"
 
 
 class UserData(IntEnum):

--- a/neon_data_models/enum.py
+++ b/neon_data_models/enum.py
@@ -36,8 +36,10 @@ class AccessRoles(IntEnum):
     admins, and owners.
 
     Special Roles:
-        NODE: Reserved for use by a Node service account
-        READ_USERS: Used by service accounts to read users from the database
+        NODE: Reserved for use by a Node device service account to access
+            various services
+        RW_USERS: Reserved for use by service accounts to access and modify the
+            users database
     """
     NONE = 0
     # 1-9 reserved for unauthenticated connections
@@ -53,7 +55,7 @@ class AccessRoles(IntEnum):
     # 50 Reserved for "unlimited access"
 
     NODE = -1
-    READ_USERS = -2, "Used by service accounts to read users from the database"
+    RW_USERS = -2
 
 
 class UserData(IntEnum):

--- a/neon_data_models/enum.py
+++ b/neon_data_models/enum.py
@@ -34,6 +34,10 @@ class AccessRoles(IntEnum):
     non-user roles. In this way, an activity can require, for example,
     `permission > AccessRoles.GUEST` to grant access to all registered users,
     admins, and owners.
+
+    Special Roles:
+        NODE: Reserved for use by a Node service account
+        READ_USERS: Used by service accounts to read users from the database
     """
     NONE = 0
     # 1-9 reserved for unauthenticated connections

--- a/neon_data_models/models/api/mq.py
+++ b/neon_data_models/models/api/mq.py
@@ -35,17 +35,25 @@ from neon_data_models.models.user.database import User, TokenConfig
 class CreateUserRequest(MQContext):
     operation: Literal["create"] = "create"
     user: User = Field(description="User object to create")
-    # TODO: Support optional auth
 
 
 class ReadUserRequest(MQContext):
     operation: Literal["read"] = "read"
     user_spec: str = Field(description="Username or User ID to read")
+    auth_user_spec: str = Field(
+        default="", description="Username or ID to authorize database  read. "
+                                "If unset, this will use `user_spec`")
     access_token: Optional[TokenConfig] = Field(
-        None, description="Token associated with `user_spec`")
+        None, description="Token associated with `auth_username`")
     password: Optional[str] = Field(None,
                                     description="Password associated with "
-                                                "`user_spec`")
+                                                "`auth_username`")
+
+    @model_validator(mode="after")
+    def get_auth_username(self) -> 'ReadUserRequest':
+        if not self.auth_user_spec:
+            self.auth_user_spec = self.user_spec
+        return self
 
 
 class UpdateUserRequest(MQContext):

--- a/neon_data_models/models/api/mq.py
+++ b/neon_data_models/models/api/mq.py
@@ -51,17 +51,16 @@ class ReadUserRequest(MQContext):
 class UpdateUserRequest(MQContext):
     operation: Literal["update"] = "update"
     user: User = Field(description="Updated User object to write to database")
-    auth_username: str = Field(default="",
-                               description="Username to authorize database "
-                                           "change. If unset, this will use "
-                                           "`user.username`")
-    auth_password: str = Field(default="",
-                               description="Password (clear or hashed) associated "
-                                      "with `auth_username`. If unset, this "
-                                      "will use `user.password_hash`. If "
-                                      "changing the password, this must "
-                                      "contain the existing password, with "
-                                      "the new password specified in `user`")
+    auth_username: str = Field(
+        default="", description="Username to authorize database change. If "
+                                "unset, this will use `user.username`")
+    auth_password: str = Field(
+        default="", description="Password (clear or hashed) associated with "
+                                "`auth_username`. If unset, this will use "
+                                "`user.password_hash`. If changing the "
+                                "password, this must contain the existing "
+                                "password, with the new password specified in "
+                                "`user`")
 
     @model_validator(mode="after")
     def get_auth_username(self) -> 'UpdateUserRequest':
@@ -70,7 +69,7 @@ class UpdateUserRequest(MQContext):
         if not self.auth_password:
             self.auth_password = self.user.password_hash
         if not all((self.auth_username, self.auth_password)):
-            raise ValueError("Missing username or password")
+            raise ValueError("Missing auth_username or auth_password")
         return self
 
 

--- a/neon_data_models/models/api/mq.py
+++ b/neon_data_models/models/api/mq.py
@@ -28,8 +28,9 @@ from typing import Literal, Optional, Annotated, Union
 
 from pydantic import Field, TypeAdapter, model_validator
 
+from neon_data_models.models.api.jwt import HanaToken
 from neon_data_models.models.base.contexts import MQContext
-from neon_data_models.models.user.database import User, TokenConfig
+from neon_data_models.models.user.database import User
 
 
 class CreateUserRequest(MQContext):
@@ -43,16 +44,19 @@ class ReadUserRequest(MQContext):
     auth_user_spec: str = Field(
         default="", description="Username or ID to authorize database  read. "
                                 "If unset, this will use `user_spec`")
-    access_token: Optional[TokenConfig] = Field(
+    access_token: Optional[HanaToken] = Field(
         None, description="Token associated with `auth_username`")
     password: Optional[str] = Field(None,
                                     description="Password associated with "
                                                 "`auth_username`")
 
     @model_validator(mode="after")
-    def get_auth_username(self) -> 'ReadUserRequest':
+    def validate_params(self) -> 'ReadUserRequest':
         if not self.auth_user_spec:
             self.auth_user_spec = self.user_spec
+        if self.access_token and self.access_token.purpose != "access":
+            raise ValueError(f"Expected an access token but got: "
+                             f"{self.access_token.purpose}")
         return self
 
 

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -23,10 +23,9 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 from datetime import datetime, timedelta
 from typing import Literal, List, Optional
-
-from pydantic import Field
 
 from neon_data_models.models.base import BaseModel
 

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -150,33 +150,18 @@ class PermissionsConfig(BaseModel):
 
 @deprecated(f"Use `neon_data_models.models.api.jwt.HanaToken`")
 class TokenConfig(BaseModel):
-    """
-    Data model for storing token data in the user database. Note that the actual
-    tokens are not included here, only metadata used to validate or invalidate a
-    token and present a list of issued tokens to the user.
-    """
-    def __init__(self, **kwargs):
-        # The JWT standard uses these standard keys; outside of that context,
-        # they are not very descriptive, so the database uses its own schema
-        if jti := kwargs.get("jti"):
-            kwargs.setdefault("token_id", jti)
-        if sub := kwargs.get("sub"):
-            kwargs.setdefault("user_id", sub)
-        if iat := kwargs.get("iat"):
-            kwargs.setdefault("creation_timestamp", iat)
-        if exp := kwargs.get("exp"):
-            kwargs.setdefault("refresh_expiration_timestamp", exp)
-        BaseModel.__init__(self, **kwargs)
-
-    token_name: str = Field(description="Human-readable token identifier")
-    token_id: str = Field(description="Unique token identifier")
-    user_id: str = Field(description="User ID the token is associated with")
-    client_id: str = Field(description="Client ID the token is associated with")
-    permissions: PermissionsConfig = Field(
-        description="Permissions for this token "
-                    "(overrides user-level permissions)")
-    refresh_expiration_timestamp: int = Field(
+    from ovos_utils.log import log_deprecation
+    log_deprecation("Use `neon_data_models.models.api.jwt.HanaToken`",
+                    "0.0.1")
+    username: str
+    client_id: str
+    permissions: Dict[str, bool]
+    refresh_token: str
+    expiration: int = Field(
+        description="Unix timestamp of auth token expiration")
+    refresh_expiration: int = Field(
         description="Unix timestamp of refresh token expiration")
+    token_name: str
     creation_timestamp: int = Field(
         description="Unix timestamp of token creation (auth+refresh)")
     last_refresh_timestamp: int = Field(

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -183,6 +183,7 @@ class TokenConfig(BaseModel):
 class User(BaseModel):
     def __init__(self, **kwargs):
         # Ensure `HanaToken` is populated from the import space
+        from neon_data_models.models.api.jwt import HanaToken
         self.model_rebuild()
         BaseModel.__init__(self, **kwargs)
 

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -150,9 +150,6 @@ class PermissionsConfig(BaseModel):
 
 @deprecated(f"Use `neon_data_models.models.api.jwt.HanaToken`")
 class TokenConfig(BaseModel):
-    from ovos_utils.log import log_deprecation
-    log_deprecation("Use `neon_data_models.models.api.jwt.HanaToken`",
-                    "0.0.1")
     username: str
     client_id: str
     permissions: Dict[str, bool]

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -162,6 +162,10 @@ class TokenConfig(BaseModel):
             kwargs.setdefault("token_id", jti)
         if sub := kwargs.get("sub"):
             kwargs.setdefault("user_id", sub)
+        if iat := kwargs.get("iat"):
+            kwargs.setdefault("creation_timestamp", iat)
+        if exp := kwargs.get("exp"):
+            kwargs.setdefault("refresh_expiration_timestamp", exp)
         BaseModel.__init__(self, **kwargs)
 
     token_name: str = Field(description="Human-readable token identifier")

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -29,7 +29,7 @@ from typing import Dict, Any, List, Literal, Optional
 from typing_extensions import deprecated
 from uuid import uuid4
 
-from neon_data_models.models.api.jwt import HanaToken
+# from neon_data_models.models.api import HanaToken
 from neon_data_models.models.base import BaseModel
 from pydantic import Field
 from datetime import date
@@ -189,7 +189,7 @@ class User(BaseModel):
     klat: KlatConfig = KlatConfig()
     llm: BrainForgeConfig = BrainForgeConfig()
     permissions: PermissionsConfig = PermissionsConfig()
-    tokens: Optional[List[HanaToken]] = []
+    tokens: Optional[List['HanaToken']] = []
 
     def __eq__(self, other):
         return self.model_dump() == other.model_dump()

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -181,6 +181,11 @@ class TokenConfig(BaseModel):
 
 
 class User(BaseModel):
+    def __init__(self, **kwargs):
+        # Ensure `HanaToken` is populated from the import space
+        self.model_rebuild()
+        BaseModel.__init__(self, **kwargs)
+
     username: str
     password_hash: Optional[str] = None
     user_id: str = Field(default_factory=lambda: str(uuid4()))

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -115,14 +115,28 @@ class BrainForgeConfig(BaseModel):
 
 class PermissionsConfig(BaseModel):
     """
-    Defines roles for supported projects/service families.
+    Defines roles for supported projects/services.
     """
-    klat: AccessRoles = AccessRoles.NONE
-    core: AccessRoles = AccessRoles.NONE
-    diana: AccessRoles = AccessRoles.NONE
-    node: AccessRoles = AccessRoles.NONE
-    hub: AccessRoles = AccessRoles.NONE
-    llm: AccessRoles = AccessRoles.NONE
+    klat: AccessRoles = Field(
+        AccessRoles.NONE, description="Defines access to Klat chat services.")
+    core: AccessRoles = Field(
+        AccessRoles.NONE, description="Defines access to Neon core services.")
+    diana: AccessRoles = Field(
+        AccessRoles.NONE,
+        description="Defines access to DIANA backend services. "
+                    "(i.e. API proxy, email proxy).")
+    users: AccessRoles = Field(
+        AccessRoles.NONE, description="Defines access to the users service.")
+    node: AccessRoles = Field(
+        AccessRoles.NONE,
+        description="Defines access to the node websocket in HANA.")
+    hub: AccessRoles = Field(
+        AccessRoles.NONE, description="Defines access to a hub device.")
+    llm: AccessRoles = Field(
+        AccessRoles.NONE,
+        description="Defines access to the BrainForge LLM backend. Note that "
+                    "per-model permissions may also apply and further restrict "
+                    "a user's access to some models for inference.")
 
     class Config:
         use_enum_values = True

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -156,8 +156,8 @@ class TokenConfig(BaseModel):
     token and present a list of issued tokens to the user.
     """
     def __init__(self, **kwargs):
-        # The JWT standard uses "jti" and "sub" for encoded values. Outside of
-        # that context, those keys are not very descriptive, so we use our own
+        # The JWT standard uses these standard keys; outside of that context,
+        # they are not very descriptive, so the database uses its own schema
         if jti := kwargs.get("jti"):
             kwargs.setdefault("token_id", jti)
         if sub := kwargs.get("sub"):

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -155,15 +155,23 @@ class TokenConfig(BaseModel):
     tokens are not included here, only metadata used to validate or invalidate a
     token and present a list of issued tokens to the user.
     """
+    def __init__(self, **kwargs):
+        # The JWT standard uses "jti" and "sub" for encoded values. Outside of
+        # that context, those keys are not very descriptive, so we use our own
+        if jti := kwargs.get("jti"):
+            kwargs.setdefault("token_id", jti)
+        if sub := kwargs.get("sub"):
+            kwargs.setdefault("user_id", sub)
+        BaseModel.__init__(self, **kwargs)
+
     token_name: str = Field(description="Human-readable token identifier")
-    token_id: str = Field(description="Unique token identifier", alias="jti")
-    user_id: str = Field(description="User ID the token is associated with",
-                         alias="sub")
+    token_id: str = Field(description="Unique token identifier")
+    user_id: str = Field(description="User ID the token is associated with")
     client_id: str = Field(description="Client ID the token is associated with")
     permissions: PermissionsConfig = Field(
         description="Permissions for this token "
                     "(overrides user-level permissions)")
-    refresh_expiration: int = Field(
+    refresh_expiration_timestamp: int = Field(
         description="Unix timestamp of refresh token expiration")
     creation_timestamp: int = Field(
         description="Unix timestamp of token creation (auth+refresh)")

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -150,15 +150,21 @@ class PermissionsConfig(BaseModel):
 
 @deprecated(f"Use `neon_data_models.models.api.jwt.HanaToken`")
 class TokenConfig(BaseModel):
-    username: str
-    client_id: str
-    permissions: Dict[str, bool]
-    refresh_token: str
-    expiration: int = Field(
-        description="Unix timestamp of auth token expiration")
+    """
+    Data model for storing token data in the user database. Note that the actual
+    tokens are not included here, only metadata used to validate or invalidate a
+    token and present a list of issued tokens to the user.
+    """
+    token_name: str = Field(description="Human-readable token identifier")
+    token_id: str = Field(description="Unique token identifier", alias="jti")
+    user_id: str = Field(description="User ID the token is associated with",
+                         alias="sub")
+    client_id: str = Field(description="Client ID the token is associated with")
+    permissions: PermissionsConfig = Field(
+        description="Permissions for this token "
+                    "(overrides user-level permissions)")
     refresh_expiration: int = Field(
         description="Unix timestamp of refresh token expiration")
-    token_name: str
     creation_timestamp: int = Field(
         description="Unix timestamp of token creation (auth+refresh)")
     last_refresh_timestamp: int = Field(

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -72,7 +72,7 @@ class TestMQ(TestCase):
 
         # Test update user valid
         valid_kwargs = {"message_id": "test_id", "operation": "update",
-                        "password": "test_password",
+                        "auth_password": "test_password",
                         "user": {"username": "test_user",
                                  "skills": {"skill_id": {"test": True}}}}
         update_request = UpdateUserRequest(**valid_kwargs)

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -42,3 +42,45 @@ class TestMQ(TestCase):
                           user="test_user", message_id="test")
         with self.assertRaises(ValidationError):
             UserDbRequest(operation="create", username="test_user")
+
+    def test_create_user_db_request(self):
+        from neon_data_models.models.api.mq import CreateUserRequest
+
+        # Test create user valid
+        valid_kwargs = {"message_id": "test_id", "operation": "create",
+                        "user": {"username": "test_user"}}
+        create_request = CreateUserRequest(**valid_kwargs)
+        self.assertIsInstance(create_request, CreateUserRequest)
+        generic_request = UserDbRequest(**valid_kwargs)
+        self.assertIsInstance(generic_request, CreateUserRequest)
+        self.assertEqual(generic_request.user.username,
+                         create_request.user.username)
+
+        # Test invalid
+        with self.assertRaises(ValidationError):
+            UserDbRequest(operation="create", message_id="test0")
+
+    def test_read_user_db_request(self):
+        from neon_data_models.models.api.mq import ReadUserRequest
+
+        # Test read user valid
+        valid_kwargs = {"message_id": "test_id", "operation": "read",
+                        "user_spec": "test_user"}
+        read_request = ReadUserRequest(**valid_kwargs)
+        self.assertIsInstance(read_request, ReadUserRequest)
+        generic_request = UserDbRequest(**valid_kwargs)
+        self.assertIsInstance(generic_request, ReadUserRequest)
+        self.assertEqual(generic_request.user_spec,
+                         read_request.user_spec)
+
+        # Test invalid
+        with self.assertRaises(ValidationError):
+            UserDbRequest(operation="create", message_id="test0")
+
+    def test_update_user_db_request(self):
+        from neon_data_models.models.api.mq import UpdateUserRequest
+        # TODO
+
+    def test_delete_user_db_request(self):
+        from neon_data_models.models.api.mq import DeleteUserRequest
+        # TODO

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -27,7 +27,6 @@
 import importlib
 import os
 from datetime import datetime, timedelta
-
 from unittest import TestCase
 from time import time
 from pydantic import ValidationError
@@ -57,7 +56,11 @@ class TestBaseModel(TestCase):
         self.assertEqual(model.model_config["extra"], "ignore")
         self.assertEqual(allowed.model_config["extra"], "allow")
 
-        importlib.reload(neon_data_models.models.base)
+        # Ensure modules are unloaded for future inheritance tests
+        import sys
+        for module in list(sys.modules.keys()):
+            if module.startswith("neon_data_models"):
+                del sys.modules[module]
 
     def test_base_model_inheritance(self):
         from neon_data_models.models.base import BaseModel

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -32,9 +32,6 @@ from unittest import TestCase
 from time import time
 from pydantic import ValidationError
 
-from neon_data_models.models.client import NodeData
-from neon_data_models.models.user import NeonUserConfig
-
 
 class TestBaseModel(TestCase):
     def test_base_model(self):
@@ -59,6 +56,15 @@ class TestBaseModel(TestCase):
         self.assertEqual(ignored.model_config["extra"], "ignore")
         self.assertEqual(model.model_config["extra"], "ignore")
         self.assertEqual(allowed.model_config["extra"], "allow")
+
+        importlib.reload(neon_data_models.models.base)
+
+    def test_base_model_inheritance(self):
+        from neon_data_models.models.base import BaseModel
+        from neon_data_models.models.user.database import PermissionsConfig
+        config = PermissionsConfig()
+        self.assertTrue(isinstance(config, BaseModel))
+        self.assertIsInstance(config.model_config["extra"], str)
 
 
 class TestContexts(TestCase):
@@ -135,6 +141,8 @@ class TestContexts(TestCase):
 class TestMessagebus(TestCase):
     def test_base_model(self):
         from neon_data_models.models.base.messagebus import BaseMessage
+        from neon_data_models.models.client import NodeData
+        from neon_data_models.models.user import NeonUserConfig
 
         with self.assertRaises(ValidationError):
             BaseMessage()
@@ -162,6 +170,8 @@ class TestMessagebus(TestCase):
 
     def test_message_context(self):
         from neon_data_models.models.base.messagebus import MessageContext
+        from neon_data_models.models.client import NodeData
+        from neon_data_models.models.user import NeonUserConfig
 
         # Default Behavior
         default_context = MessageContext()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -42,6 +42,8 @@ class TestImports(TestCase):
         from neon_data_models.models.user import User
         from neon_data_models.models.user.database import User as _User
         self.assertEqual(User, _User)
+        user = User(username="test_user", password_hash="test_pass")
+        self.assertIsInstance(user, User)
 
     def test_import_subclasses(self):
         # Addressing circular import noted in users service unit tests

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -24,42 +24,31 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Optional, List, Union
-from pydantic import ConfigDict, Field
-
-from neon_data_models.models.base import BaseModel
-from neon_data_models.models.base.contexts import (SessionContext, KlatContext,
-                                                   TimingContext, MQContext)
-from neon_data_models.models.client.node import NodeData
-from neon_data_models.models.user.database import NeonUserConfig
+from unittest import TestCase
 
 
-class MessageContext(BaseModel):
-    model_config = ConfigDict(extra="allow")
-    session: Optional[SessionContext] = Field(description="Session Data",
-                                              default=None)
-    node_data: Optional[NodeData] = Field(description="Node Data", default=None)
-    timing: Optional[TimingContext] = Field(
-        description="User Interaction Timing Information", default=None)
-    user_profiles: Optional[List[NeonUserConfig]] = (
-        Field(description="List of relevant user profiles", default=None))
-    klat_data: Optional[KlatContext] = Field(
-        description="Klat context for Klat-generated messages", default=None)
-    mq: Optional[MQContext] = Field(
-        description="MQ context for messages traversing a RabbitMQ broker",
-        default=None)
+class TestImports(TestCase):
+    def test_import_api(self):
+        from neon_data_models.models.api import CreateUserRequest
+        from neon_data_models.models.api.mq import CreateUserRequest as _CUR
+        self.assertEqual(CreateUserRequest, _CUR)
 
-    username: str = "local"
-    # TODO: Consider refactoring client/client_name into a single dict
-    #  or merging with `node_data`
-    client_name: str = "unknown"
-    client: str = "unknown"
-    source: Union[str, List[str]] = "unknown"
-    destination: List[str] = ["skills"]
-    neon_should_respond: bool = True
+    def test_import_client(self):
+        from neon_data_models.models.client import NodeData
+        from neon_data_models.models.client.node import NodeData as _ND
+        self.assertEqual(NodeData, _ND)
 
+    def test_import_user(self):
+        from neon_data_models.models.user import User
+        from neon_data_models.models.user.database import User as _User
+        self.assertEqual(User, _User)
 
-class BaseMessage(BaseModel):
-    msg_type: str
-    data: dict
-    context: MessageContext
+    def test_import_subclasses(self):
+        # Addressing circular import noted in users service unit tests
+        from neon_data_models.models.user.database import User
+        from neon_data_models.models.client.node import NodeData
+        from neon_data_models.models.api.mq import CreateUserRequest
+        from neon_data_models.models.base import BaseModel
+        self.assertTrue(issubclass(CreateUserRequest, BaseModel))
+        self.assertTrue(issubclass(NodeData, BaseModel))
+        self.assertTrue(issubclass(User, BaseModel))


### PR DESCRIPTION
# Description
Refactors `UserDbRequest` into seprate schemas for CRUD operations
Maintains compat. with users service by determining model based on the requested `operation`
Adds a `users` permissions config and annotates `PermissionsConfig` values

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Needs to be rebased on `dev` after merge of #2