### PR TITLE
Define data models for LLM interactions

### DIFF
--- a/neon_data_models/models/__init__.py
+++ b/neon_data_models/models/__init__.py
@@ -25,5 +25,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from neon_data_models.models.user import *
+User.rebuild_model()
+
 from neon_data_models.models.client import *
 from neon_data_models.models.api import *

--- a/neon_data_models/models/__init__.py
+++ b/neon_data_models/models/__init__.py
@@ -23,3 +23,7 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from neon_data_models.models.user import *
+from neon_data_models.models.client import *
+from neon_data_models.models.api import *

--- a/neon_data_models/models/api/__init__.py
+++ b/neon_data_models/models/api/__init__.py
@@ -27,3 +27,4 @@
 from neon_data_models.models.api.node_v1 import *
 from neon_data_models.models.api.mq import *
 from neon_data_models.models.api.jwt import *
+from neon_data_models.models.api.llm import *

--- a/neon_data_models/models/api/__init__.py
+++ b/neon_data_models/models/api/__init__.py
@@ -25,6 +25,6 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from neon_data_models.models.api.node_v1 import *
-from neon_data_models.models.api.mq import *
 from neon_data_models.models.api.jwt import *
 from neon_data_models.models.api.llm import *
+from neon_data_models.models.api.mq import *

--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -88,7 +88,7 @@ class LLMRequest(BaseModel):
         default=None, description="Enable streaming responses. "
                                   "Mutually exclusive with `beam_search`.")
     best_of: int = Field(
-        default=1,
+        default=1, ge=1,
         description="Number of beams to use if `beam_search` is enabled.")
     beam_search: bool = Field(
         default=None, description="Enable beam search. "
@@ -126,6 +126,10 @@ class LLMRequest(BaseModel):
                 raise ValueError("Cannot enable both `stream` and "
                                  "`beam_search`")
             self.beam_search = False
+        # If beam search is enabled, `best_of` must be >1
+        if self.beam_search is True and self.best_of <= 1:
+            raise ValueError(f"best_of must be greater than 1 when using "
+                             f"beam search. Got {self.best_of}")
         # If beam search is enabled, streaming must be False
         if self.beam_search is True:
             if self.stream is True:

--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -30,6 +30,9 @@ from pydantic import Field, model_validator
 from neon_data_models.models.base import BaseModel
 
 
+_DEFAULT_MQ_TO_ROLE = {"user": "user", "llm": "assistant"}
+
+
 class LLMPersona(BaseModel):
     name: str = Field(description="Unique name for this persona")
     description: Optional[str] = Field(
@@ -48,7 +51,8 @@ class LLMPersona(BaseModel):
 
 class LLMRequest(BaseModel):
     query: str = Field(description="Incoming user prompt")
-    history: List[Tuple[Literal["user", "assistant"], str]] = Field(
+    # TODO: History may support more options in the future
+    history: List[Tuple[Literal["user", "llm"], str]] = Field(
         description="OpenAI-formatted chat history (excluding system prompt)")
     persona: LLMPersona = Field(
         description="Requested persona to respond to this message")
@@ -83,8 +87,8 @@ class LLMRequest(BaseModel):
         # Neon modules previously defined `user` and `llm` keys, but Open AI
         # specifies `assistant` in place of `llm` and is the de-facto standard
         for idx, itm in enumerate(values.get('history', [])):
-            if itm[0] == "llm":
-                values['history'][idx] = ("assistant", itm[1])
+            if itm[0] == "assistant":
+                values['history'][idx] = ("llm", itm[1])
         return values
 
     @model_validator(mode='after')
@@ -126,11 +130,16 @@ class LLMRequest(BaseModel):
         """
         return [{"role": m[0], "content": m[1]} for m in self.history]
 
-    def to_completion_kwargs(self) -> dict:
+    def to_completion_kwargs(self, mq2role: dict = None) -> dict:
         """
-        Get kwargs to pass to an OpenAI completion request
+        Get kwargs to pass to an OpenAI completion request.
+        @param mq2role: dict mapping `llm` and `user` keys to `role` values to
+            use in message history.
         """
+        mq2role = mq2role or _DEFAULT_MQ_TO_ROLE
         history = self.messages[-2*self.max_history:]
+        for msg in history:
+            msg["role"] = mq2role.get(msg["role"]) or msg["role"]
         history.insert(0, {"role": "system",
                            "content": self.persona.system_prompt})
         return {"model": self.model,
@@ -146,7 +155,7 @@ class LLMRequest(BaseModel):
 
 class LLMResponse(BaseModel):
     response: str = Field(description="LLM Response to the input query")
-    history: List[Tuple[Literal["user", "assistant"], str]] = Field(
+    history: List[Tuple[Literal["user", "llm"], str]] = Field(
         description="List of (role, content) tuples in chronological order "
                     "(`response` is in the last list element)")
 
@@ -156,8 +165,8 @@ class LLMResponse(BaseModel):
         # Neon modules previously defined `user` and `llm` keys, but Open AI
         # specifies `assistant` in place of `llm` and is the de-facto standard
         for idx, itm in enumerate(values.get('history', [])):
-            if itm[0] == "llm":
-                values['history'][idx] = ("assistant", itm[1])
+            if itm[0] == "assistant":
+                values['history'][idx] = ("llm", itm[1])
         return values
 
 

--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -25,7 +25,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from typing import List, Tuple, Optional, Literal
-from pydantic import Field, model_validator
+from pydantic import Field, model_validator, computed_field
 
 from neon_data_models.models.base import BaseModel
 
@@ -40,6 +40,11 @@ class LLMPersona(BaseModel):
     system_prompt: str = Field(
         None, description="System prompt associated with this persona. "
                           "If None, `description` will be used.")
+    enabled: bool = Field(
+        True, description="Flag used to mark a defined persona as "
+                          "available for use.")
+    user_id: Optional[str] = Field(
+        None, description="`user_id` of the user who created this persona.")
 
     @model_validator(mode='after')
     def validate_request(self):
@@ -47,6 +52,14 @@ class LLMPersona(BaseModel):
         if self.system_prompt is None:
             self.system_prompt = self.description
         return self
+
+    @computed_field
+    @property
+    def id(self) -> str:
+        persona_id = self.name
+        if self.user_id:
+            persona_id += f"_{self.user_id}"
+        return persona_id
 
 
 class LLMRequest(BaseModel):

--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -1,0 +1,144 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2024 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import List, Tuple, Optional, Literal
+from pydantic import Field, model_validator
+
+from neon_data_models.models.base import BaseModel
+
+
+class LLMPersona(BaseModel):
+    name: str = Field(description="Unique name for this persona")
+    description: Optional[str] = Field(
+        None, description="Human-readable description of this persona")
+    system_prompt: str = Field(
+        None, description="System prompt associated with this persona. "
+                          "If None, `description` will be used.")
+
+    @model_validator(mode='after')
+    def validate_request(self):
+        assert any((self.description, self.system_prompt))
+        if self.system_prompt is None:
+            self.system_prompt = self.description
+        return self
+
+
+class LLMRequest(BaseModel):
+    query: str = Field(description="Incoming user prompt")
+    history: List[Tuple[Literal["user", "assistant"], str]] = Field(
+        description="OpenAI-formatted chat history (excluding system prompt)")
+    persona: LLMPersona = Field(
+        description="Requested persona to respond to this message")
+    model: str = Field(description="Model to request")
+    max_tokens: int = Field(
+        default=512, ge=64, le=2048,
+        description="Maximum number of tokens to include in the response")
+    temperature: float = Field(
+        default=0.0, ge=0.0, le=1.0,
+        description="Temperature of response. 0 guarantees reproducibility, "
+                    "higher values increase variability.")
+    repetition_penalty: float = Field(
+        default=1.0, ge=1.0, le=2.0,
+        description="Repetition penalty. Higher values limit repeated "
+                    "information in responses")
+    stream: bool = Field(
+        default=None, description="Enable streaming responses. "
+                                  "Mutually exclusive with `beam_search`.")
+    best_of: int = Field(
+        default=1,
+        description="Number of beams to use if `beam_search` is enabled.")
+    beam_search: bool = Field(
+        default=None, description="Enable beam search. "
+                                  "Mutually exclusive with `stream`.")
+    max_history: int = Field(
+        default=2, description="Maximum number of user/assistant "
+                               "message pairs to include in history context.")
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_inputs(cls, values):
+        # Neon modules previously defined `user` and `llm` keys, but Open AI
+        # specifies `assistant` in place of `llm` and is the de-facto standard
+        for idx, itm in enumerate(values.get('history', [])):
+            if itm[0] == "llm":
+                values['history'][idx] = ("assistant", itm[1])
+        return values
+
+    @model_validator(mode='after')
+    def validate_request(self):
+        # If beams are specified, make sure valid `stream` and `beam_search`
+        # values are specified
+        if self.best_of > 1:
+            if self.stream is True:
+                raise ValueError("Cannot stream with a `best_of` value "
+                                 "greater than 1")
+            if self.beam_search is False:
+                raise ValueError("Cannot have a `best_of` value other than 1 "
+                                 "if `beam_search` is False")
+            self.stream = False
+            self.beam_search = True
+        # If streaming, beam_search must be False
+        if self.stream is True:
+            if self.beam_search is True:
+                raise ValueError("Cannot enable both `stream` and "
+                                 "`beam_search`")
+            self.beam_search = False
+        # If beam search is enabled, streaming must be False
+        if self.beam_search is True:
+            if self.stream is True:
+                raise ValueError("Cannot enable both `stream` and "
+                                 "`beam_search`")
+            self.stream = False
+        if self.stream is None and self.beam_search is None:
+            self.stream = True
+            self.beam_search = False
+        assert isinstance(self.stream, bool)
+        assert isinstance(self.beam_search, bool)
+        return self
+
+    @property
+    def messages(self) -> List[dict]:
+        """
+        Get chat history as a list of dict messages
+        """
+        return [{"role": m[0], "content": m[1]} for m in self.history]
+
+    def to_completion_kwargs(self) -> dict:
+        """
+        Get kwargs to pass to an OpenAI completion request
+        """
+        history = self.messages[-2*self.max_history:]
+        history.insert(0, {"role": "system",
+                           "content": self.persona.system_prompt})
+        return {"model": self.model,
+                "messages": history,
+                "max_tokens": self.max_tokens,
+                "temperature": self.temperature,
+                "stream": self.stream,
+                "extra_body": {"add_special_tokens": True,
+                               "repetition_penalty": self.repetition_penalty,
+                               "use_beam_search": self.beam_search,
+                               "best_of": self.best_of}}

--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -76,7 +76,8 @@ class LLMRequest(BaseModel):
     temperature: float = Field(
         default=0.0, ge=0.0, le=1.0,
         description="Temperature of response. 0 guarantees reproducibility, "
-                    "higher values increase variability.")
+                    "higher values increase variability. Must be `0.0` if "
+                    "`beam_search` is True")
     repetition_penalty: float = Field(
         default=1.0, ge=1.0, le=2.0,
         description="Repetition penalty. Higher values limit repeated "
@@ -132,8 +133,13 @@ class LLMRequest(BaseModel):
         if self.stream is None and self.beam_search is None:
             self.stream = True
             self.beam_search = False
+
         assert isinstance(self.stream, bool)
         assert isinstance(self.beam_search, bool)
+
+        # If beam search is enabled, temperature must be set to 0.0
+        if self.beam_search:
+            assert self.temperature == 0.0
         return self
 
     @property

--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -179,6 +179,8 @@ class LLMResponse(BaseModel):
     history: List[Tuple[Literal["user", "llm"], str]] = Field(
         description="List of (role, content) tuples in chronological order "
                     "(`response` is in the last list element)")
+    finish_reason: Literal["length", "stop"] = Field(
+        "stop", description="Reason response generation ended.")
 
     @model_validator(mode='before')
     @classmethod

--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -66,7 +66,9 @@ class LLMRequest(BaseModel):
     query: str = Field(description="Incoming user prompt")
     # TODO: History may support more options in the future
     history: List[Tuple[Literal["user", "llm"], str]] = Field(
-        description="OpenAI-formatted chat history (excluding system prompt)")
+        description="Formatted chat history (excluding system prompt). Note "
+                    "that the roles used here will differ from those used in "
+                    "OpenAI-compatible requests.")
     persona: LLMPersona = Field(
         description="Requested persona to respond to this message")
     model: str = Field(description="Model to request")

--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -142,3 +142,23 @@ class LLMRequest(BaseModel):
                                "repetition_penalty": self.repetition_penalty,
                                "use_beam_search": self.beam_search,
                                "best_of": self.best_of}}
+
+
+class LLMResponse(BaseModel):
+    response: str = Field(description="LLM Response to the input query")
+    history: List[Tuple[Literal["user", "assistant"], str]] = Field(
+        description="List of (role, content) tuples in chronological order "
+                    "(`response` is in the last list element)")
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_inputs(cls, values):
+        # Neon modules previously defined `user` and `llm` keys, but Open AI
+        # specifies `assistant` in place of `llm` and is the de-facto standard
+        for idx, itm in enumerate(values.get('history', [])):
+            if itm[0] == "llm":
+                values['history'][idx] = ("assistant", itm[1])
+        return values
+
+
+__all__ = [LLMPersona.__name__, LLMRequest.__name__, LLMResponse.__name__]

--- a/neon_data_models/models/api/mq.py
+++ b/neon_data_models/models/api/mq.py
@@ -24,7 +24,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Literal, Optional, Annotated, Union
+from typing import Literal, Optional, Annotated, Union, Dict, List
 
 from pydantic import Field, TypeAdapter, model_validator
 
@@ -105,7 +105,7 @@ class UserDbRequest:
         return cls.ta.validate_python(kwargs)
 
 
-class MqLlmRequest(MQContext, LLMRequest):
+class LLMProposeRequest(MQContext, LLMRequest):
     model: Optional[str] = Field(
         default=None,
         description="MQ implementation defines `model` as optional because the "
@@ -117,6 +117,32 @@ class MqLlmRequest(MQContext, LLMRequest):
                     "LLM module.")
 
 
+class LLMProposeResponse(MQContext):
+    response: str = Field(description="LLM response to the prompt")
+
+
+class LLMDiscussRequest(LLMProposeRequest):
+    options: Dict[str, str] = Field(
+        description="Mapping of participant name to response to be discussed.")
+
+
+class LLMDiscussResponse(MQContext):
+    opinion: str = Field(description="LLM response to the available options.")
+
+
+class LLMVoteRequest(LLMProposeRequest):
+    responses: List[str] = Field(
+        description="List of responses to choose from.")
+
+
+class LLMVoteResponse(MQContext):
+    sorted_answer_indexes: List[int] = Field(
+        description="Indices of `responses` ordered high to low by preference.")
+
+
 __all__ = [CreateUserRequest.__name__, ReadUserRequest.__name__,
            UpdateUserRequest.__name__, DeleteUserRequest.__name__,
-           UserDbRequest.__name__, MqLlmRequest.__name__]
+           UserDbRequest.__name__, LLMProposeRequest.__name__,
+           LLMProposeResponse.__name__, LLMDiscussRequest.__name__,
+           LLMDiscussResponse.__name__, LLMVoteRequest.__name__,
+           LLMVoteResponse.__name__]

--- a/neon_data_models/models/api/mq.py
+++ b/neon_data_models/models/api/mq.py
@@ -29,6 +29,7 @@ from typing import Literal, Optional, Annotated, Union
 from pydantic import Field, TypeAdapter, model_validator
 
 from neon_data_models.models.api.jwt import HanaToken
+from neon_data_models.models.api.llm import LLMRequest, LLMPersona
 from neon_data_models.models.base.contexts import MQContext
 from neon_data_models.models.user.database import User
 
@@ -104,6 +105,18 @@ class UserDbRequest:
         return cls.ta.validate_python(kwargs)
 
 
+class MqLlmRequest(MQContext, LLMRequest):
+    model: Optional[str] = Field(
+        default=None,
+        description="MQ implementation defines `model` as optional because the "
+                    "queue defines the requested model in most cases.")
+    persona: Optional[LLMPersona] = Field(
+        default=None,
+        description="MQ implementation defines `persona` as an optional "
+                    "parameter, with default behavior hard-coded into each "
+                    "LLM module.")
+
+
 __all__ = [CreateUserRequest.__name__, ReadUserRequest.__name__,
            UpdateUserRequest.__name__, DeleteUserRequest.__name__,
-           UserDbRequest.__name__]
+           UserDbRequest.__name__, MqLlmRequest.__name__]

--- a/neon_data_models/models/api/mq/__init__.py
+++ b/neon_data_models/models/api/mq/__init__.py
@@ -1,0 +1,28 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2024 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from neon_data_models.models.api.mq.llm import *
+from neon_data_models.models.api.mq.users import *

--- a/neon_data_models/models/api/mq/llm.py
+++ b/neon_data_models/models/api/mq/llm.py
@@ -1,0 +1,71 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2024 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Optional, Dict, List
+from pydantic import Field
+
+from neon_data_models.models.api.llm import LLMRequest, LLMPersona
+from neon_data_models.models.base.contexts import MQContext
+
+
+class LLMProposeRequest(MQContext, LLMRequest):
+    model: Optional[str] = Field(
+        default=None,
+        description="MQ implementation defines `model` as optional because the "
+                    "queue defines the requested model in most cases.")
+    persona: Optional[LLMPersona] = Field(
+        default=None,
+        description="MQ implementation defines `persona` as an optional "
+                    "parameter, with default behavior hard-coded into each "
+                    "LLM module.")
+
+
+class LLMProposeResponse(MQContext):
+    response: str = Field(description="LLM response to the prompt")
+
+
+class LLMDiscussRequest(LLMProposeRequest):
+    options: Dict[str, str] = Field(
+        description="Mapping of participant name to response to be discussed.")
+
+
+class LLMDiscussResponse(MQContext):
+    opinion: str = Field(description="LLM response to the available options.")
+
+
+class LLMVoteRequest(LLMProposeRequest):
+    responses: List[str] = Field(
+        description="List of responses to choose from.")
+
+
+class LLMVoteResponse(MQContext):
+    sorted_answer_indexes: List[int] = Field(
+        description="Indices of `responses` ordered high to low by preference.")
+
+
+__all__ = [LLMProposeRequest.__name__, LLMProposeResponse.__name__,
+           LLMDiscussRequest.__name__, LLMDiscussResponse.__name__,
+           LLMVoteRequest.__name__, LLMVoteResponse.__name__]

--- a/neon_data_models/models/api/mq/users.py
+++ b/neon_data_models/models/api/mq/users.py
@@ -33,6 +33,11 @@ from neon_data_models.models.user.database import User
 
 
 class CreateUserRequest(MQContext):
+    def __init__(self, **kwargs):
+        # `User` may be rebuilt upon init, so make sure this model is too
+        self.model_rebuild()
+        MQContext.__init__(self, **kwargs)
+
     operation: Literal["create"] = "create"
     user: User = Field(description="User object to create")
 
@@ -60,6 +65,11 @@ class ReadUserRequest(MQContext):
 
 
 class UpdateUserRequest(MQContext):
+    def __init__(self, **kwargs):
+        # `User` may be rebuilt upon init, so make sure this model is too
+        self.model_rebuild()
+        MQContext.__init__(self, **kwargs)
+
     operation: Literal["update"] = "update"
     user: User = Field(description="Updated User object to write to database")
     auth_username: str = Field(
@@ -85,6 +95,11 @@ class UpdateUserRequest(MQContext):
 
 
 class DeleteUserRequest(MQContext):
+    def __init__(self, **kwargs):
+        # `User` may be rebuilt upon init, so make sure this model is too
+        self.model_rebuild()
+        MQContext.__init__(self, **kwargs)
+
     operation: Literal["delete"] = "delete"
     user: User = Field(description="Exact User object to remove from the "
                                    "database")

--- a/neon_data_models/models/api/mq/users.py
+++ b/neon_data_models/models/api/mq/users.py
@@ -35,6 +35,7 @@ from neon_data_models.models.user.database import User
 class CreateUserRequest(MQContext):
     def __init__(self, **kwargs):
         # `User` may be rebuilt upon init, so make sure this model is too
+        User.model_rebuild()
         self.model_rebuild()
         MQContext.__init__(self, **kwargs)
 
@@ -67,6 +68,7 @@ class ReadUserRequest(MQContext):
 class UpdateUserRequest(MQContext):
     def __init__(self, **kwargs):
         # `User` may be rebuilt upon init, so make sure this model is too
+        User.model_rebuild()
         self.model_rebuild()
         MQContext.__init__(self, **kwargs)
 
@@ -97,6 +99,7 @@ class UpdateUserRequest(MQContext):
 class DeleteUserRequest(MQContext):
     def __init__(self, **kwargs):
         # `User` may be rebuilt upon init, so make sure this model is too
+        User.model_rebuild()
         self.model_rebuild()
         MQContext.__init__(self, **kwargs)
 

--- a/neon_data_models/models/api/mq/users.py
+++ b/neon_data_models/models/api/mq/users.py
@@ -33,12 +33,6 @@ from neon_data_models.models.user.database import User
 
 
 class CreateUserRequest(MQContext):
-    def __init__(self, **kwargs):
-        # `User` may be rebuilt upon init, so make sure this model is too
-        User.model_rebuild()
-        self.model_rebuild()
-        MQContext.__init__(self, **kwargs)
-
     operation: Literal["create"] = "create"
     user: User = Field(description="User object to create")
 
@@ -66,12 +60,6 @@ class ReadUserRequest(MQContext):
 
 
 class UpdateUserRequest(MQContext):
-    def __init__(self, **kwargs):
-        # `User` may be rebuilt upon init, so make sure this model is too
-        User.model_rebuild()
-        self.model_rebuild()
-        MQContext.__init__(self, **kwargs)
-
     operation: Literal["update"] = "update"
     user: User = Field(description="Updated User object to write to database")
     auth_username: str = Field(
@@ -97,12 +85,6 @@ class UpdateUserRequest(MQContext):
 
 
 class DeleteUserRequest(MQContext):
-    def __init__(self, **kwargs):
-        # `User` may be rebuilt upon init, so make sure this model is too
-        User.model_rebuild()
-        self.model_rebuild()
-        MQContext.__init__(self, **kwargs)
-
     operation: Literal["delete"] = "delete"
     user: User = Field(description="Exact User object to remove from the "
                                    "database")

--- a/neon_data_models/models/api/mq/users.py
+++ b/neon_data_models/models/api/mq/users.py
@@ -24,12 +24,10 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Literal, Optional, Annotated, Union, Dict, List
-
+from typing import Literal, Optional, Annotated, Union
 from pydantic import Field, TypeAdapter, model_validator
 
 from neon_data_models.models.api.jwt import HanaToken
-from neon_data_models.models.api.llm import LLMRequest, LLMPersona
 from neon_data_models.models.base.contexts import MQContext
 from neon_data_models.models.user.database import User
 
@@ -105,44 +103,6 @@ class UserDbRequest:
         return cls.ta.validate_python(kwargs)
 
 
-class LLMProposeRequest(MQContext, LLMRequest):
-    model: Optional[str] = Field(
-        default=None,
-        description="MQ implementation defines `model` as optional because the "
-                    "queue defines the requested model in most cases.")
-    persona: Optional[LLMPersona] = Field(
-        default=None,
-        description="MQ implementation defines `persona` as an optional "
-                    "parameter, with default behavior hard-coded into each "
-                    "LLM module.")
-
-
-class LLMProposeResponse(MQContext):
-    response: str = Field(description="LLM response to the prompt")
-
-
-class LLMDiscussRequest(LLMProposeRequest):
-    options: Dict[str, str] = Field(
-        description="Mapping of participant name to response to be discussed.")
-
-
-class LLMDiscussResponse(MQContext):
-    opinion: str = Field(description="LLM response to the available options.")
-
-
-class LLMVoteRequest(LLMProposeRequest):
-    responses: List[str] = Field(
-        description="List of responses to choose from.")
-
-
-class LLMVoteResponse(MQContext):
-    sorted_answer_indexes: List[int] = Field(
-        description="Indices of `responses` ordered high to low by preference.")
-
-
 __all__ = [CreateUserRequest.__name__, ReadUserRequest.__name__,
            UpdateUserRequest.__name__, DeleteUserRequest.__name__,
-           UserDbRequest.__name__, LLMProposeRequest.__name__,
-           LLMProposeResponse.__name__, LLMDiscussRequest.__name__,
-           LLMDiscussResponse.__name__, LLMVoteRequest.__name__,
-           LLMVoteResponse.__name__]
+           UserDbRequest.__name__]

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -181,11 +181,12 @@ class TokenConfig(BaseModel):
 
 
 class User(BaseModel):
-    def __init__(self, **kwargs):
+
+    @classmethod
+    def rebuild_model(cls):
         # Ensure `HanaToken` is populated from the import space
         from neon_data_models.models.api.jwt import HanaToken
-        self.model_rebuild()
-        BaseModel.__init__(self, **kwargs)
+        cls.model_rebuild()
 
     username: str
     password_hash: Optional[str] = None

--- a/tests/models/api/test_llm.py
+++ b/tests/models/api/test_llm.py
@@ -119,7 +119,11 @@ class TestLLM(TestCase):
             LLMRequest(query=test_query, history=test_history,
                        persona=test_persona, model=test_model, stream=True,
                        best_of=2)
-
+        # Invalid temperature with beam search
+        with self.assertRaises(ValidationError):
+            LLMRequest(query=test_query, history=test_history,
+                       persona=test_persona, model=test_model, stream=False,
+                       temperature=0.8)
         # Invalid history
         test_history.append(("invalid_key", "okay"))
         with self.assertRaises(ValidationError):

--- a/tests/models/api/test_llm.py
+++ b/tests/models/api/test_llm.py
@@ -1,0 +1,128 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2024 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from unittest import TestCase
+from pydantic import ValidationError
+
+
+class TestLLM(TestCase):
+    def test_llm_persona(self):
+        from neon_data_models.models.api.llm import LLMPersona
+        legacy_mq_persona = LLMPersona(name="my persona",
+                                       description="You are a helpful chatbot.")
+        self.assertEqual(legacy_mq_persona.system_prompt,
+                         legacy_mq_persona.description)
+
+        legacy_bf_persona = LLMPersona(name="neon",
+                                       system_prompt="You are NeonLLM.")
+        self.assertIsNone(legacy_bf_persona.description)
+        self.assertEqual(legacy_bf_persona.system_prompt,
+                         "You are NeonLLM.")
+
+        full_persona = LLMPersona(name="custom chatbot",
+                                  description="A customized bot for something",
+                                  system_prompt="You are a custom chatbot.")
+        self.assertEqual(full_persona.system_prompt,
+                         "You are a custom chatbot.")
+        self.assertEqual(full_persona.description,
+                         "A customized bot for something")
+
+        with self.assertRaises(ValidationError):
+            LLMPersona(name="underdefined persona")
+
+    def test_llm_request(self):
+        from neon_data_models.models.api.llm import LLMRequest, LLMPersona
+        test_query = "how are you?"
+        test_history = [("user", "hello"),
+                        ("assistant", "Hi, how can I help you today?"),
+                        ("user", "I am well, how about you?"),
+                        ("assistant", "As a large language model, I do not feel")]
+        test_persona = {"name": "Test Bot",
+                        "system_prompt": "This is the system prompt."}
+        test_model = "my_model_spec"
+        # Minimal definition
+        valid_request = LLMRequest(query=test_query, history=test_history,
+                                   persona=test_persona, model=test_model)
+        self.assertIsInstance(valid_request.persona, LLMPersona)
+        self.assertTrue(valid_request.stream)
+        self.assertFalse(valid_request.beam_search)
+        self.assertEqual(len(valid_request.history), len(test_history))
+        self.assertEqual(len(valid_request.to_completion_kwargs()['messages']),
+                         2 * valid_request.max_history + 1)
+
+        # Valid explicit streaming
+        streaming_request = LLMRequest(query=test_query, history=test_history,
+                                       persona=test_persona, model=test_model,
+                                       stream=True)
+        self.assertEqual(streaming_request, valid_request)
+
+        # Valid explicit beam search
+        beam_search_request = LLMRequest(query=test_query, history=test_history,
+                                         persona=test_persona, model=test_model,
+                                         beam_search=True)
+        self.assertTrue(beam_search_request.beam_search)
+        self.assertFalse(beam_search_request.stream)
+
+        # Valid best_of, implied beam search
+        best_of_request = LLMRequest(query=test_query, history=test_history,
+                                     persona=test_persona, model=test_model,
+                                     best_of=3)
+        self.assertTrue(best_of_request.beam_search)
+        self.assertFalse(best_of_request.stream)
+
+        # Valid explicitly disable streaming and beam search
+        valid_no_stream = LLMRequest(query=test_query, history=test_history,
+                                     persona=test_persona, model=test_model,
+                                     stream=False, beam_search=False)
+        self.assertFalse(valid_no_stream.beam_search)
+        self.assertFalse(valid_no_stream.stream)
+
+        # Validate `llm` history input
+        old_history = [("user", "hello"),
+                       ("llm", "Hi, how can I help you today?"),
+                       ("user", "I am well, how about you?"),
+                       ("llm", "As a large language model, I do not feel")]
+        validated = LLMRequest(query=test_query, history=old_history,
+                               persona=test_persona, model=test_model)
+        self.assertEqual(validated.history, test_history)
+
+        # Invalid streaming with beam search
+        with self.assertRaises(ValidationError):
+            LLMRequest(query=test_query, history=test_history,
+                       persona=test_persona, model=test_model, stream=True,
+                       beam_search=True)
+        # Invalid streaming with best_of > 1
+        with self.assertRaises(ValidationError):
+            LLMRequest(query=test_query, history=test_history,
+                       persona=test_persona, model=test_model, stream=True,
+                       best_of=2)
+
+        # Invalid history
+        test_history.append(("invalid_key", "okay"))
+        with self.assertRaises(ValidationError):
+            LLMRequest(query=test_query, history=test_history,
+                       persona=test_persona, model=test_model)
+        test_history.pop()

--- a/tests/models/api/test_llm.py
+++ b/tests/models/api/test_llm.py
@@ -82,7 +82,7 @@ class TestLLM(TestCase):
         # Valid explicit beam search
         beam_search_request = LLMRequest(query=test_query, history=test_history,
                                          persona=test_persona, model=test_model,
-                                         beam_search=True)
+                                         beam_search=True, best_of=2)
         self.assertTrue(beam_search_request.beam_search)
         self.assertFalse(beam_search_request.stream)
 
@@ -123,7 +123,12 @@ class TestLLM(TestCase):
         with self.assertRaises(ValidationError):
             LLMRequest(query=test_query, history=test_history,
                        persona=test_persona, model=test_model, stream=False,
-                       temperature=0.8)
+                       temperature=0.8, best_of=2)
+        # Invalid beam search with best_of=1
+        with self.assertRaises(ValidationError):
+            LLMRequest(query=test_query, history=test_history,
+                       persona=test_persona, model=test_model, stream=False,
+                       temperature=0.8, beam_search=True, best_of=1)
         # Invalid history
         test_history.append(("invalid_key", "okay"))
         with self.assertRaises(ValidationError):

--- a/tests/models/api/test_llm.py
+++ b/tests/models/api/test_llm.py
@@ -128,7 +128,7 @@ class TestLLM(TestCase):
         with self.assertRaises(ValidationError):
             LLMRequest(query=test_query, history=test_history,
                        persona=test_persona, model=test_model, stream=False,
-                       temperature=0.8, beam_search=True, best_of=1)
+                       beam_search=True, best_of=1)
         # Invalid history
         test_history.append(("invalid_key", "okay"))
         with self.assertRaises(ValidationError):

--- a/tests/models/api/test_llm.py
+++ b/tests/models/api/test_llm.py
@@ -126,3 +126,28 @@ class TestLLM(TestCase):
             LLMRequest(query=test_query, history=test_history,
                        persona=test_persona, model=test_model)
         test_history.pop()
+
+    def test_llm_response(self):
+        from neon_data_models.models.api.llm import LLMResponse
+        valid_response = "hello"
+        valid_history = [("user", "hello"), ("assistant", "How can I help?")]
+        legacy_history = [("user", "hello"), ("llm", "How can I help?")]
+
+        # Valid response with valid history
+        response = LLMResponse(response=valid_response, history=valid_history)
+        self.assertEqual(response.response, valid_response)
+        self.assertEqual(response.history, valid_history)
+
+        # Valid response with legacy history
+        response = LLMResponse(response=valid_response, history=legacy_history)
+        self.assertEqual(response.response, valid_response)
+        self.assertEqual(response.history, valid_history)
+
+        # Invalid response
+        with self.assertRaises(ValidationError):
+            LLMResponse(response=None, history=valid_history)
+
+        # Invalid history
+        valid_history.append(("invalid", "response"))
+        with self.assertRaises(ValidationError):
+            LLMResponse(response=valid_response, history=valid_history)

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -128,7 +128,7 @@ class TestMQ(TestCase):
                           message_id="test0")
 
     def test_mq_llm_request(self):
-        from neon_data_models.models.api.mq import MqLlmRequest
+        from neon_data_models.models.api.mq import LLMProposeRequest
         from neon_data_models.models.api.llm import LLMRequest
         from neon_data_models.models.base.contexts import MQContext
 
@@ -139,17 +139,17 @@ class TestMQ(TestCase):
         message_id = "test_mid"
 
         # Valid fully-defined
-        valid_request = MqLlmRequest(query=query, history=history,
-                                     persona=persona, model=model_name,
-                                     message_id=message_id)
-        self.assertIsInstance(valid_request, MqLlmRequest)
+        valid_request = LLMProposeRequest(query=query, history=history,
+                                          persona=persona, model=model_name,
+                                          message_id=message_id)
+        self.assertIsInstance(valid_request, LLMProposeRequest)
         self.assertIsInstance(valid_request, LLMRequest)
         self.assertIsInstance(valid_request, MQContext)
 
         # Valid backwards-compat (no model or persona)
-        backwards_compat = MqLlmRequest(query=query, history=history,
-                                        message_id=message_id)
-        self.assertIsInstance(backwards_compat, MqLlmRequest)
+        backwards_compat = LLMProposeRequest(query=query, history=history,
+                                             message_id=message_id)
+        self.assertIsInstance(backwards_compat, LLMProposeRequest)
         self.assertIsInstance(backwards_compat, LLMRequest)
         self.assertIsInstance(backwards_compat, MQContext)
         self.assertIsNone(backwards_compat.model)
@@ -157,13 +157,13 @@ class TestMQ(TestCase):
 
         # Invalid Persona defined
         with self.assertRaises(ValidationError):
-            MqLlmRequest(query=query, history=history,  message_id=message_id,
-                         persona={})
+            LLMProposeRequest(query=query, history=history, message_id=message_id,
+                              persona={})
 
         # Invalid MQ Context
         with self.assertRaises(ValidationError):
-            MqLlmRequest(query=query, history=history)
+            LLMProposeRequest(query=query, history=history)
 
         # Invalid LLM Request
         with self.assertRaises(ValidationError):
-            MqLlmRequest(history=history, message_id=message_id)
+            LLMProposeRequest(history=history, message_id=message_id)

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -95,7 +95,8 @@ class TestMQ(TestCase):
         update = UpdateUserRequest(message_id="test_id", operation="update",
                                    user={"username": "user",
                                          "password_hash": "password"},
-                                   auth_username="admin", auth_password="admin_pass")
+                                   auth_username="admin",
+                                   auth_password="admin_pass")
         self.assertEqual(update.user.username, "user")
         self.assertEqual(update.user.password_hash, "password")
 
@@ -157,8 +158,8 @@ class TestMQ(TestCase):
 
         # Invalid Persona defined
         with self.assertRaises(ValidationError):
-            LLMProposeRequest(query=query, history=history, message_id=message_id,
-                              persona={})
+            LLMProposeRequest(query=query, history=history,
+                              message_id=message_id, persona={})
 
         # Invalid MQ Context
         with self.assertRaises(ValidationError):

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -128,7 +128,7 @@ class TestMQ(TestCase):
             UserDbRequest(operation="delete", username="test_user",
                           message_id="test0")
 
-    def test_mq_llm_request(self):
+    def test_mq_llm_propose_request(self):
         from neon_data_models.models.api.mq import LLMProposeRequest
         from neon_data_models.models.api.llm import LLMRequest
         from neon_data_models.models.base.contexts import MQContext
@@ -168,3 +168,111 @@ class TestMQ(TestCase):
         # Invalid LLM Request
         with self.assertRaises(ValidationError):
             LLMProposeRequest(history=history, message_id=message_id)
+
+    def test_mq_llm_propose_response(self):
+        from neon_data_models.models.api.mq import LLMProposeResponse
+
+        # Valid response
+        self.assertIsInstance(LLMProposeResponse(response="test response",
+                                                 message_id=""),
+                              LLMProposeResponse)
+
+        # Missing MQ required data
+        with self.assertRaises(ValidationError):
+            LLMProposeResponse(response="test response")
+
+        # Missing response required data
+        with self.assertRaises(ValidationError):
+            LLMProposeResponse(message_id="")
+
+    def test_mq_llm_discuss_request(self):
+        from neon_data_models.models.api.mq import LLMDiscussRequest
+        query = "who are you"
+        history = []
+        message_id = "test_mid"
+        opts = {"bot 1": "resp 1", "bot 2": "resp 2"}
+        invalid_opts = {"bot 1": "resp 1", "bot 2": None}
+
+        # Valid request
+        valid_request = LLMDiscussRequest(query=query, history=history,
+                                          message_id=message_id, options=opts)
+        self.assertIsInstance(valid_request, LLMDiscussRequest)
+
+        # Invalid options
+        with self.assertRaises(ValidationError):
+            LLMDiscussRequest(query=query, history=history,
+                              message_id=message_id, options=invalid_opts)
+
+        # Invalid MQ Context
+        with self.assertRaises(ValidationError):
+            LLMDiscussRequest(query=query, history=history, options=opts)
+
+        # Invalid LLM Request
+        with self.assertRaises(ValidationError):
+            LLMDiscussRequest(query=query, message_id=message_id, options=opts)
+
+    def test_mq_llm_discuss_response(self):
+        from neon_data_models.models.api.mq import LLMDiscussResponse
+
+        # Valid response
+        self.assertIsInstance(LLMDiscussResponse(opinion="test opinion",
+                                                 message_id=""),
+                              LLMDiscussResponse)
+
+        # Missing MQ required data
+        with self.assertRaises(ValidationError):
+            LLMDiscussResponse(opinion="test opinion")
+
+        # Missing response required data
+        with self.assertRaises(ValidationError):
+            LLMDiscussResponse(message_id="")
+
+    def test_mq_llm_vote_request(self):
+        from neon_data_models.models.api.mq import LLMVoteRequest
+        query = "who are you"
+        history = []
+        message_id = "test_mid"
+        responses = ["resp 1", "resp 2"]
+        invalid_responses = ["resp 1", "resp 2", None]
+
+        # Valid request
+        valid_request = LLMVoteRequest(query=query, history=history,
+                                       message_id=message_id,
+                                       responses=responses)
+        self.assertIsInstance(valid_request, LLMVoteRequest)
+
+        # Invalid options
+        with self.assertRaises(ValidationError):
+            LLMVoteRequest(query=query, history=history, message_id=message_id,
+                           responses=invalid_responses)
+
+        # Invalid MQ Context
+        with self.assertRaises(ValidationError):
+            LLMVoteRequest(query=query, history=history, responses=responses)
+
+        # Invalid LLM Request
+        with self.assertRaises(ValidationError):
+            LLMVoteRequest(query=query, message_id=message_id,
+                           responses=responses)
+
+    def test_mq_llm_vote_response(self):
+        from neon_data_models.models.api.mq import LLMVoteResponse
+
+        # Valid response
+        self.assertIsInstance(LLMVoteResponse(sorted_answer_indexes=[2, 0, 1],
+                                              message_id=""),
+                              LLMVoteResponse)
+
+        # Missing MQ required data
+        with self.assertRaises(ValidationError):
+            LLMVoteResponse(sorted_answer_indexes=[2, 0, 1])
+
+        # Missing response required data
+        with self.assertRaises(ValidationError):
+            LLMVoteResponse(message_id="")
+
+        # Invalid response data
+        with self.assertRaises(ValidationError):
+            LLMVoteResponse(sorted_answer_indexes=[2, 0, 1, "invalid"],
+                            message_id=""),
+

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -126,3 +126,44 @@ class TestMQ(TestCase):
         with self.assertRaises(ValidationError):
             UserDbRequest(operation="delete", username="test_user",
                           message_id="test0")
+
+    def test_mq_llm_request(self):
+        from neon_data_models.models.api.mq import MqLlmRequest
+        from neon_data_models.models.api.llm import LLMRequest
+        from neon_data_models.models.base.contexts import MQContext
+
+        query = "who are you"
+        history = []
+        model_name = "test_model"
+        persona = {"name": "test_persona", "system_prompt": "Test prompt."}
+        message_id = "test_mid"
+
+        # Valid fully-defined
+        valid_request = MqLlmRequest(query=query, history=history,
+                                     persona=persona, model=model_name,
+                                     message_id=message_id)
+        self.assertIsInstance(valid_request, MqLlmRequest)
+        self.assertIsInstance(valid_request, LLMRequest)
+        self.assertIsInstance(valid_request, MQContext)
+
+        # Valid backwards-compat (no model or persona)
+        backwards_compat = MqLlmRequest(query=query, history=history,
+                                        message_id=message_id)
+        self.assertIsInstance(backwards_compat, MqLlmRequest)
+        self.assertIsInstance(backwards_compat, LLMRequest)
+        self.assertIsInstance(backwards_compat, MQContext)
+        self.assertIsNone(backwards_compat.model)
+        self.assertIsNone(backwards_compat.persona)
+
+        # Invalid Persona defined
+        with self.assertRaises(ValidationError):
+            MqLlmRequest(query=query, history=history,  message_id=message_id,
+                         persona={})
+
+        # Invalid MQ Context
+        with self.assertRaises(ValidationError):
+            MqLlmRequest(query=query, history=history)
+
+        # Invalid LLM Request
+        with self.assertRaises(ValidationError):
+            MqLlmRequest(history=history, message_id=message_id)

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -27,12 +27,10 @@
 from unittest import TestCase
 from pydantic import ValidationError
 
-from neon_data_models.models.api.mq import UserDbRequest
-
 
 class TestMQ(TestCase):
     def test_create_user_db_request(self):
-        from neon_data_models.models.api.mq import CreateUserRequest
+        from neon_data_models.models.api.mq.users import UserDbRequest, CreateUserRequest
 
         # Test create user valid
         valid_kwargs = {"message_id": "test_id", "operation": "create",
@@ -50,7 +48,7 @@ class TestMQ(TestCase):
                           message_id="test0")
 
     def test_read_user_db_request(self):
-        from neon_data_models.models.api.mq import ReadUserRequest
+        from neon_data_models.models.api.mq.users import UserDbRequest, ReadUserRequest
 
         # Test read user valid
         valid_kwargs = {"message_id": "test_id", "operation": "read",
@@ -68,7 +66,7 @@ class TestMQ(TestCase):
                           message_id="test0")
 
     def test_update_user_db_request(self):
-        from neon_data_models.models.api.mq import UpdateUserRequest
+        from neon_data_models.models.api.mq.users import UserDbRequest, UpdateUserRequest
 
         # Test update user valid
         valid_kwargs = {"message_id": "test_id", "operation": "update",
@@ -111,7 +109,7 @@ class TestMQ(TestCase):
                           message_id="test0")
 
     def test_delete_user_db_request(self):
-        from neon_data_models.models.api.mq import DeleteUserRequest
+        from neon_data_models.models.api.mq.users import UserDbRequest, DeleteUserRequest
 
         # Test delete user valid
         valid_kwargs = {"message_id": "test_id", "operation": "delete",
@@ -129,7 +127,7 @@ class TestMQ(TestCase):
                           message_id="test0")
 
     def test_mq_llm_propose_request(self):
-        from neon_data_models.models.api.mq import LLMProposeRequest
+        from neon_data_models.models.api.mq.llm import LLMProposeRequest
         from neon_data_models.models.api.llm import LLMRequest
         from neon_data_models.models.base.contexts import MQContext
 
@@ -170,7 +168,7 @@ class TestMQ(TestCase):
             LLMProposeRequest(history=history, message_id=message_id)
 
     def test_mq_llm_propose_response(self):
-        from neon_data_models.models.api.mq import LLMProposeResponse
+        from neon_data_models.models.api.mq.llm import LLMProposeResponse
 
         # Valid response
         self.assertIsInstance(LLMProposeResponse(response="test response",
@@ -186,7 +184,7 @@ class TestMQ(TestCase):
             LLMProposeResponse(message_id="")
 
     def test_mq_llm_discuss_request(self):
-        from neon_data_models.models.api.mq import LLMDiscussRequest
+        from neon_data_models.models.api.mq.llm import LLMDiscussRequest
         query = "who are you"
         history = []
         message_id = "test_mid"
@@ -212,7 +210,7 @@ class TestMQ(TestCase):
             LLMDiscussRequest(query=query, message_id=message_id, options=opts)
 
     def test_mq_llm_discuss_response(self):
-        from neon_data_models.models.api.mq import LLMDiscussResponse
+        from neon_data_models.models.api.mq.llm import LLMDiscussResponse
 
         # Valid response
         self.assertIsInstance(LLMDiscussResponse(opinion="test opinion",
@@ -228,7 +226,7 @@ class TestMQ(TestCase):
             LLMDiscussResponse(message_id="")
 
     def test_mq_llm_vote_request(self):
-        from neon_data_models.models.api.mq import LLMVoteRequest
+        from neon_data_models.models.api.mq.llm import LLMVoteRequest
         query = "who are you"
         history = []
         message_id = "test_mid"
@@ -256,7 +254,7 @@ class TestMQ(TestCase):
                            responses=responses)
 
     def test_mq_llm_vote_response(self):
-        from neon_data_models.models.api.mq import LLMVoteResponse
+        from neon_data_models.models.api.mq.llm import LLMVoteResponse
 
         # Valid response
         self.assertIsInstance(LLMVoteResponse(sorted_answer_indexes=[2, 0, 1],


### PR DESCRIPTION
# Description
Add `llm` module
Defines LLMPersona from backend implementation
Defines LLMRequest based on HANA and BrainForge implementations
Defines MQ API for LLM interactions

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
This is compatible with the current implementation in HANA, but it will reformat requests st history follows the OpenAI format
This implements some logic in the BrainForge webapp demo, adding some validation of parameters
This includes some refactoring of module init to resolve circular import/partial-init errors