### PR TITLE
Resolve issue with serializing default permissions

### DIFF
--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -31,7 +31,7 @@ from uuid import uuid4
 
 # from neon_data_models.models.api import HanaToken
 from neon_data_models.models.base import BaseModel
-from pydantic import Field
+from pydantic import Field, ConfigDict
 from datetime import date
 
 from neon_data_models.enum import AccessRoles
@@ -126,7 +126,8 @@ class PermissionsConfig(BaseModel):
         description="Defines access to DIANA backend services. "
                     "(i.e. API proxy, email proxy).")
     users: AccessRoles = Field(
-        AccessRoles.NONE, description="Defines access to the users service.")
+        default_factory=lambda: AccessRoles.NONE,
+        description="Defines access to the users service.")
     node: AccessRoles = Field(
         AccessRoles.NONE,
         description="Defines access to the node websocket in HANA.")
@@ -140,6 +141,7 @@ class PermissionsConfig(BaseModel):
 
     class Config:
         use_enum_values = True
+        validate_default = True
 
     @classmethod
     def from_roles(cls, roles: List[str]):

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -126,8 +126,7 @@ class PermissionsConfig(BaseModel):
         description="Defines access to DIANA backend services. "
                     "(i.e. API proxy, email proxy).")
     users: AccessRoles = Field(
-        default_factory=lambda: AccessRoles.NONE,
-        description="Defines access to the users service.")
+        AccessRoles.NONE, description="Defines access to the users service.")
     node: AccessRoles = Field(
         AccessRoles.NONE,
         description="Defines access to the node websocket in HANA.")

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -31,7 +31,7 @@ from uuid import uuid4
 
 # from neon_data_models.models.api import HanaToken
 from neon_data_models.models.base import BaseModel
-from pydantic import Field, ConfigDict
+from pydantic import Field
 from datetime import date
 
 from neon_data_models.enum import AccessRoles

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -85,6 +85,7 @@ class TestDatabase(TestCase):
         self.assertIsInstance(config.user.dob, date)
 
     def test_user(self):
+        from neon_data_models.enum import AccessRoles
         user_kwargs = dict(username="test",
                            password_hash="test",
                            tokens=[{"token_name": "test_token",
@@ -98,6 +99,11 @@ class TestDatabase(TestCase):
                                     "last_refresh_timestamp": round(time())}])
         default_user = User(**user_kwargs)
         self.assertIsInstance(default_user.tokens[0], HanaToken)
+
+        dumped = default_user.model_dump()
+        for perm in dumped['permissions']:
+            self.assertEqual(int, type(dumped['permissions'][perm]), perm)
+            self.assertIsInstance(AccessRoles(dumped['permissions'][perm]), AccessRoles, perm)
         with self.assertRaises(ValidationError):
             User()
 
@@ -124,8 +130,14 @@ class TestDatabase(TestCase):
                                         node=AccessRoles.NODE,
                                         hub=AccessRoles.NODE,
                                         llm=AccessRoles.NONE)
+
+        # Test dumped enums
+        dumped = test_config.model_dump()
+        for key, value in dumped.items():
+            self.assertEqual(type(value), int, key)
+
         # Test dump/load
-        self.assertEqual(PermissionsConfig(**test_config.model_dump()),
+        self.assertEqual(PermissionsConfig(**dumped),
                          test_config)
 
         # Test to/from roles


### PR DESCRIPTION
# Description
Add unit test to address observed permissions serialization issue
Update `PermissionsConfig` to ensure default values are properly serialized

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Issue observed in alpha and beta deployments of the `neon-users-service` when creating new users with default settings

Solution found in https://github.com/pydantic/pydantic/issues/7757