### PR TITLE
Add support for "vanilla" persona with unit tests

### DIFF
--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -58,6 +58,11 @@ class LLMPersona(LLMPersonaIdentity):
 
     @model_validator(mode='after')
     def validate_request(self):
+        if self.name == "vanilla":
+            assert self.system_prompt in (None, "")
+            self.system_prompt = None
+            return self
+
         assert any((self.description, self.system_prompt))
         if self.system_prompt is None:
             self.system_prompt = self.description

--- a/tests/models/api/test_llm.py
+++ b/tests/models/api/test_llm.py
@@ -31,17 +31,20 @@ from pydantic import ValidationError
 class TestLLM(TestCase):
     def test_llm_persona(self):
         from neon_data_models.models.api.llm import LLMPersona
+        # Valid description
         legacy_mq_persona = LLMPersona(name="my persona",
                                        description="You are a helpful chatbot.")
         self.assertEqual(legacy_mq_persona.system_prompt,
                          legacy_mq_persona.description)
 
+        # Valid system prompt
         legacy_bf_persona = LLMPersona(name="neon",
                                        system_prompt="You are NeonLLM.")
         self.assertIsNone(legacy_bf_persona.description)
         self.assertEqual(legacy_bf_persona.system_prompt,
                          "You are NeonLLM.")
 
+        # Fully-defined persona
         full_persona = LLMPersona(name="custom chatbot",
                                   description="A customized bot for something",
                                   system_prompt="You are a custom chatbot.")
@@ -50,8 +53,20 @@ class TestLLM(TestCase):
         self.assertEqual(full_persona.description,
                          "A customized bot for something")
 
+        # Under-defined persona
         with self.assertRaises(ValidationError):
             LLMPersona(name="underdefined persona")
+
+        # Valid vanilla persona
+        vanilla = LLMPersona(name="vanilla")
+        self.assertIsNone(vanilla.system_prompt)
+
+        vanilla_2 = LLMPersona(name="vanilla", description="A vanilla chatbot")
+        self.assertIsNone(vanilla_2.system_prompt)
+
+        # Invalid vanilla persona
+        with self.assertRaises(ValidationError):
+            LLMPersona(name="vanilla", system_prompt="This should be empty")
 
     def test_llm_request(self):
         from neon_data_models.models.api.llm import LLMRequest, LLMPersona


### PR DESCRIPTION
# Description
Makes "vanilla" a reserved persona name that does not have an associated system prompt
Adds unit tests to cover model validation of "vanilla" persona

# Issues
Closes #9

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->