### PR TITLE
Implement models for Neon MQ API

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -8,3 +8,5 @@ on:
 jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
+    with:
+      packages-exclude: '^(neon-data-models|dnspython|typing_extensions).*'

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -8,5 +8,3 @@ on:
 jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
-    with:
-      packages-exclude: '^(neon-data-models|dnspython).*'

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the

--- a/neon_data_models/__init__.py
+++ b/neon_data_models/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/enum.py
+++ b/neon_data_models/enum.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/__init__.py
+++ b/neon_data_models/models/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/api/__init__.py
+++ b/neon_data_models/models/api/__init__.py
@@ -28,3 +28,4 @@ from neon_data_models.models.api.node_v1 import *
 from neon_data_models.models.api.jwt import *
 from neon_data_models.models.api.llm import *
 from neon_data_models.models.api.mq import *
+from neon_data_models.models.api.messagebus import *

--- a/neon_data_models/models/api/__init__.py
+++ b/neon_data_models/models/api/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/api/jwt.py
+++ b/neon_data_models/models/api/jwt.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -1,0 +1,126 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2024 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+Defines models for `Message` objects sent on the Neon messagebus.
+"""
+
+from typing import Any, List, Literal, Dict
+from pydantic import Field, model_validator
+
+from neon_data_models.types import gender
+from neon_data_models.models.base import BaseModel
+from neon_data_models.models.base.messagebus import BaseMessage
+
+
+# Data models
+class GetTtsData(BaseModel):
+    text: str = Field(description="Text to be spoken")
+    lang: str = Field(default="en-us",
+                      description="BCP-47 language code for TTS")
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_inputs(cls, values):
+        if hasattr(values, 'model_dump'):
+            values = values.model_dump()
+        if 'text' not in values:
+            values['text'] = values.get('utterance')
+        return values
+
+
+class TtsResponse(BaseModel):
+    sentence: str
+    translated: bool
+    phonemes: str
+
+
+class TtsReponseData(BaseModel):
+    responses: Dict[str, Dict[gender, TtsResponse]]
+
+
+class GetSttData(BaseModel):
+    audio_data: str = Field(description="Base64-encoded audio data")
+    lang: str = Field(default="en-us",
+                      description="BCP-47 language code for STT")
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_inputs(cls, values):
+        if hasattr(values, 'model_dump'):
+            values = values.model_dump()
+        if 'audio_data' not in values:
+            values['audio_data'] = values.get('message_body')
+        return values
+
+
+class SttReponseData(BaseModel):
+    transcripts: List[str]
+    parser_data: Dict[str, Any]
+
+
+class GetResponseData(BaseModel):
+    utterances: List[str] = Field(description="List of input utterance(s)")
+    lang: str = Field(default="en-us",
+                      description="BCP-47 language code for input/response")
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_inputs(cls, values):
+        if hasattr(values, 'model_dump'):
+            values = values.model_dump()
+        if 'utterances' not in values:
+            values['utterances'] = [values.pop('messageText', '')]
+        return values
+
+
+# Message models
+class NeonGetTts(BaseMessage):
+    msg_type: Literal["neon.get_tts"] = "neon.get_tts"
+    data: GetTtsData
+
+
+class NeonGetStt(BaseMessage):
+    msg_type: Literal["neon.get_stt"] = "neon.get_stt"
+    data: GetSttData
+
+
+class NeonGetResponse(BaseMessage):
+    msg_type: Literal["recognizer_loop:utterance"] = "recognizer_loop:utterance"
+    data: GetResponseData
+
+
+class NeonSttResponse(BaseMessage):
+    msg_type: Literal["neon.get_stt.response"] = "neon.get_stt.response"
+    data: SttReponseData
+
+
+class NeonTtsResponse(BaseMessage):
+    msg_type: Literal["neon.get_tts.response",
+                      "klat.response"] = "neon.get_tts.response"
+    data: TtsReponseData
+
+__all__ = [NeonGetTts.__name__, NeonGetStt.__name__, NeonGetResponse.__name__,
+           NeonSttResponse.__name__, NeonTtsResponse.__name__]

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -27,7 +27,7 @@
 Defines models for `Message` objects sent on the Neon messagebus.
 """
 
-from typing import Any, List, Literal, Dict
+from typing import Any, List, Literal, Dict, Optional
 from pydantic import Field, model_validator
 
 from neon_data_models.types import Gender
@@ -54,7 +54,7 @@ class GetTtsData(BaseModel):
 class TtsResponse(BaseModel):
     sentence: str
     translated: bool
-    phonemes: str = Field(default="",
+    phonemes: Optional[str] = Field(default=None,
                            description="Phoneme representation of the sentence")
     genders: List[Gender]
     audio: Dict[Gender, str]

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -52,20 +52,58 @@ class GetTtsData(BaseModel):
 
 
 class TtsResponse(BaseModel):
-    sentence: str
-    translated: bool
+    sentence: str = Field(description="Text to be spoken")
+    translated: bool = Field(
+        default=False, 
+        description="True if the text has been translated before TTS synthesis")
     phonemes: Optional[str] = Field(
         default=None, description="Phoneme representation of the sentence")
-    genders: List[Gender]
+    genders: List[Gender] = Field(
+        description="List of genders included in the response `audio` field",
+        deprecated=True)
     male: Optional[str] = Field(default=None,
                                  description="Path to audio file in male voice")
     female: Optional[str] = Field(
         default=None, description="Path to audio file in female voice")
     audio: Dict[Gender, str]
+    
+    @model_validator(mode='after')
+    def validate_gender_audio_match(self):
+        """Validate that the genders list matches the audio dictionary keys."""
+        if not set(self.genders) == set(self.audio.keys()):
+            raise ValueError(
+                "All genders listed in 'genders' must have corresponding "
+                "entries in 'audio'")
+        return self
+
+
+class TtsSpeaker(BaseModel):
+    name: str = Field(default="Neon", description="Name of the speaker")
+    speaker: Optional[str] = Field(
+        default=None, 
+        description="Deprecated: Use 'name' instead",
+        deprecated=True)
+    language: str = Field(default="en-us", description="BCP-47 language code")
+    gender: Gender = Field(default="female",
+                          description="Requested or synthesized gender")
+    voice: Optional[str] = Field(
+        default=None, description="Requested or synthesized voice name")
+    
+    @model_validator(mode='before')
+    @classmethod
+    def map_speaker_to_name(cls, values):
+        if hasattr(values, 'model_dump'):
+            values = values.model_dump()
+        if 'name' not in values and 'speaker' in values:
+            values['name'] = values['speaker']
+        return values
 
 
 class TtsReponseData(BaseModel):
-    responses: Dict[str, TtsResponse]
+    responses: Dict[str, TtsResponse] = Field(
+        description="Dictionary of BCP-47 lang codes to TTS responses")
+    speaker: Optional[TtsSpeaker] = Field(
+        default=None, description="Optional speaker metadata")
 
 
 class GetSttData(BaseModel):
@@ -86,6 +124,13 @@ class GetSttData(BaseModel):
 class SttReponseData(BaseModel):
     transcripts: List[str]
     parser_data: Dict[str, Any]
+    
+    @model_validator(mode='after')
+    def validate_transcripts_not_empty(self):
+        """Validate that the transcripts list is not empty."""
+        if not self.transcripts:
+            raise ValueError("'transcripts' cannot be an empty list")
+        return self
 
 
 class GetResponseData(BaseModel):

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -30,7 +30,7 @@ Defines models for `Message` objects sent on the Neon messagebus.
 from typing import Any, List, Literal, Dict
 from pydantic import Field, model_validator
 
-from neon_data_models.types import gender
+from neon_data_models.types import Gender
 from neon_data_models.models.base import BaseModel
 from neon_data_models.models.base.messagebus import BaseMessage
 
@@ -55,10 +55,12 @@ class TtsResponse(BaseModel):
     sentence: str
     translated: bool
     phonemes: str
+    genders: List[Gender]
+    audio: Dict[Gender, str]
 
 
 class TtsReponseData(BaseModel):
-    responses: Dict[str, Dict[gender, TtsResponse]]
+    responses: Dict[str, TtsResponse]
 
 
 class GetSttData(BaseModel):

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -54,7 +54,8 @@ class GetTtsData(BaseModel):
 class TtsResponse(BaseModel):
     sentence: str
     translated: bool
-    phonemes: str
+    phonemes: str = Field(default="",
+                           description="Phoneme representation of the sentence")
     genders: List[Gender]
     audio: Dict[Gender, str]
 

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -107,9 +107,14 @@ class NeonGetStt(BaseMessage):
     data: GetSttData
 
 
-class NeonGetResponse(BaseMessage):
+class NeonTextInput(BaseMessage):
     msg_type: Literal["recognizer_loop:utterance"] = "recognizer_loop:utterance"
     data: GetResponseData
+
+
+class NeonAudioInput(BaseMessage):
+    msg_type: Literal["neon.audio_input"] = "neon.audio_input"
+    data: GetSttData
 
 
 class NeonSttResponse(BaseMessage):
@@ -122,5 +127,6 @@ class NeonTtsResponse(BaseMessage):
                       "klat.response"] = "neon.get_tts.response"
     data: TtsReponseData
 
-__all__ = [NeonGetTts.__name__, NeonGetStt.__name__, NeonGetResponse.__name__,
-           NeonSttResponse.__name__, NeonTtsResponse.__name__]
+__all__ = [NeonGetTts.__name__, NeonGetStt.__name__, NeonTextInput.__name__,
+           NeonAudioInput.__name__, NeonSttResponse.__name__,
+           NeonTtsResponse.__name__]

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -162,20 +162,44 @@ class NeonGetTts(BaseMessage):
     msg_type: Literal["neon.get_tts"] = "neon.get_tts"
     data: GetTtsData
 
+    @model_validator(mode='after')
+    def ensure_audio_destination(self):
+        if "audio" not in self.context.destination:
+            self.context.destination.append("audio")
+        return self
+
 
 class NeonGetStt(BaseMessage):
     msg_type: Literal["neon.get_stt"] = "neon.get_stt"
     data: GetSttData
+
+    @model_validator(mode='after')
+    def ensure_audio_destination(self):
+        if "audio" not in self.context.destination:
+            self.context.destination.append("audio")
+        return self
 
 
 class NeonTextInput(BaseMessage):
     msg_type: Literal["recognizer_loop:utterance"] = "recognizer_loop:utterance"
     data: GetResponseData
 
+    @model_validator(mode='after')
+    def ensure_skills_destination(self):
+        if "skills" not in self.context.destination:
+            self.context.destination.append("skills")
+        return self
+
 
 class NeonAudioInput(BaseMessage):
     msg_type: Literal["neon.audio_input"] = "neon.audio_input"
     data: GetSttData
+
+    @model_validator(mode='after')
+    def ensure_audio_destination(self):
+        if "audio" not in self.context.destination:
+            self.context.destination.append("audio")
+        return self
 
 
 class NeonSttResponse(BaseMessage):

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -99,6 +99,12 @@ class GetResponseData(BaseModel):
         return values
 
 
+class NeonLanguagesData(BaseModel):
+    stt: List[str] = Field(description="List of supported STT languages")
+    tts: List[str] = Field(description="List of supported TTS languages")
+    skills: List[str] = Field(description="List of supported skill languages")
+
+
 # Message models
 class NeonGetTts(BaseMessage):
     msg_type: Literal["neon.get_tts"] = "neon.get_tts"
@@ -130,6 +136,17 @@ class NeonTtsResponse(BaseMessage):
                       "klat.response"] = "neon.get_tts.response"
     data: TtsReponseData
 
+
+class NeonGetLanguages(BaseMessage):
+    msg_type: Literal["neon.languages.get"] = "neon.languages.get"
+    
+
+class NeonLanguagesResponse(BaseMessage):
+    msg_type: Literal["neon.languages.get.response"] = "neon.languages.get.response"
+    data: NeonLanguagesData
+
+
 __all__ = [NeonGetTts.__name__, NeonGetStt.__name__, NeonTextInput.__name__,
            NeonAudioInput.__name__, NeonSttResponse.__name__,
-           NeonTtsResponse.__name__]
+           NeonTtsResponse.__name__, NeonGetLanguages.__name__,
+           NeonLanguagesResponse.__name__]

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -44,6 +44,7 @@ class GetTtsData(BaseModel):
     @model_validator(mode='before')
     @classmethod
     def validate_inputs(cls, values):
+        # Ensure input values are normalized to valid field names
         if hasattr(values, 'model_dump'):
             values = values.model_dump()
         if 'text' not in values:
@@ -114,6 +115,7 @@ class GetSttData(BaseModel):
     @model_validator(mode='before')
     @classmethod
     def validate_inputs(cls, values):
+        # Ensure input values are normalized to valid field names
         if hasattr(values, 'model_dump'):
             values = values.model_dump()
         if 'audio_data' not in values:
@@ -141,6 +143,7 @@ class GetResponseData(BaseModel):
     @model_validator(mode='before')
     @classmethod
     def validate_inputs(cls, values):
+        # Ensure input values are normalized to valid field names
         if hasattr(values, 'model_dump'):
             values = values.model_dump()
         if 'utterances' not in values:

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -54,8 +54,8 @@ class GetTtsData(BaseModel):
 class TtsResponse(BaseModel):
     sentence: str
     translated: bool
-    phonemes: Optional[str] = Field(default=None,
-                           description="Phoneme representation of the sentence")
+    phonemes: Optional[str] = Field(
+        default=None, description="Phoneme representation of the sentence")
     genders: List[Gender]
     audio: Dict[Gender, str]
 

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -57,6 +57,10 @@ class TtsResponse(BaseModel):
     phonemes: Optional[str] = Field(
         default=None, description="Phoneme representation of the sentence")
     genders: List[Gender]
+    male: Optional[str] = Field(default=None,
+                                 description="Path to audio file in male voice")
+    female: Optional[str] = Field(
+        default=None, description="Path to audio file in female voice")
     audio: Dict[Gender, str]
 
 

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -165,7 +165,7 @@ class NeonGetTts(BaseMessage):
     @model_validator(mode='after')
     def ensure_audio_destination(self):
         if "audio" not in self.context.destination:
-            self.context.destination.append("audio")
+            self.context.destination = ["audio"]
         return self
 
 
@@ -176,7 +176,8 @@ class NeonGetStt(BaseMessage):
     @model_validator(mode='after')
     def ensure_audio_destination(self):
         if "audio" not in self.context.destination:
-            self.context.destination.append("audio")
+            # Default context is not valid for this request, so override it
+            self.context.destination = ["audio"]
         return self
 
 
@@ -198,7 +199,8 @@ class NeonAudioInput(BaseMessage):
     @model_validator(mode='after')
     def ensure_audio_destination(self):
         if "audio" not in self.context.destination:
-            self.context.destination.append("audio")
+            # Default context is not valid for this request, so override it
+            self.context.destination = ["audio"]
         return self
 
 

--- a/neon_data_models/models/api/mq/__init__.py
+++ b/neon_data_models/models/api/mq/__init__.py
@@ -26,3 +26,4 @@
 
 from neon_data_models.models.api.mq.llm import *
 from neon_data_models.models.api.mq.users import *
+from neon_data_models.models.api.mq.neon import *

--- a/neon_data_models/models/api/mq/__init__.py
+++ b/neon_data_models/models/api/mq/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/api/mq/llm.py
+++ b/neon_data_models/models/api/mq/llm.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -130,6 +130,10 @@ class NeonMqUnknownMessage(BaseMessage, MQContext):
 
 
 class NeonApiMessage:
+    """
+    Type adapter for validating an arbitrary MQ message. This will always return
+    an instance that extends `BaseMessage` and `MQContext`.
+    """
     ta = TypeAdapter(Annotated[Union[NeonMqGetStt, NeonMqGetTts,
                                      NeonMqTextInput, NeonMqSttResponse,
                                      NeonMqTtsResponse, NeonMqGetLanguages,
@@ -153,6 +157,9 @@ class NeonApiMessage:
 
     @staticmethod
     def from_sio_message(sio_message: dict) -> BaseMessage:
+        """
+        Parse a Klat SocketIO message into a valid MQ API message
+        """
         requested_service = sio_message.get("requested_skill",
                                          "recognizer").lower()
         if requested_service not in ["stt", "tts", "recognizer"]:

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -32,8 +32,8 @@ from neon_data_models.models.base.contexts import KlatContext, MQContext, \
     SessionContext, TimingContext
 from neon_data_models.models.base.messagebus import BaseMessage, MessageContext
 from neon_data_models.models.user.database import NeonUserConfig
-from neon_data_models.models.api.messagebus import NeonGetTts, NeonGetStt, \
-    NeonAudioInput, NeonTextInput, NeonSttResponse, NeonTtsResponse
+from neon_data_models.models.api.messagebus import NeonGetLanguages, NeonGetTts, NeonGetStt, \
+    NeonAudioInput, NeonLanguagesResponse, NeonTextInput, NeonSttResponse, NeonTtsResponse
 
 
 class GetTtsData(BaseModel):
@@ -97,10 +97,19 @@ class NeonMqTtsResponse(NeonTtsResponse, MQContext):
     pass
 
 
+class NeonMqGetLanguages(NeonGetLanguages, MQContext):
+    pass
+
+
+class NeonMqLanguagesResponse(NeonLanguagesResponse, MQContext):
+    pass
+
+
 class NeonApiMessage:
     ta = TypeAdapter(Annotated[Union[NeonMqGetStt, NeonMqGetTts,
                                      NeonMqTextInput, NeonMqSttResponse,
-                                     NeonMqTtsResponse],
+                                     NeonMqTtsResponse, NeonMqGetLanguages,
+                                     NeonMqLanguagesResponse],
                                Field(discriminator='msg_type')])
 
     @classmethod
@@ -147,4 +156,5 @@ class NeonApiMessage:
 
 __all__ = [NeonMqGetTts.__name__, NeonMqGetStt.__name__, 
            NeonMqTextInput.__name__, NeonMqSttResponse.__name__,
-           NeonMqTtsResponse.__name__, NeonApiMessage.__name__]
+           NeonMqTtsResponse.__name__, NeonMqGetLanguages.__name__,
+           NeonMqLanguagesResponse.__name__, NeonApiMessage.__name__]

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -28,7 +28,7 @@ from typing import List, Literal, Optional, Annotated, Union
 from pydantic import Field, TypeAdapter, model_validator
 
 from neon_data_models.models.base import BaseModel
-from neon_data_models.models.base.contexts import KlatContext, MQContext, TimingContext
+from neon_data_models.models.base.contexts import KlatContext, MQContext, SessionContext, TimingContext
 from neon_data_models.models.base.messagebus import BaseMessage, MessageContext
 from neon_data_models.models.user.database import NeonUserConfig
 
@@ -100,6 +100,8 @@ class NeonApiMessage(BaseModel):
                                  username=sio_message.get("nick", "guest"),
                                  klat_data=klat_context, mq=mq_context,
                                  user_profiles=[NeonUserConfig()],
+                                 session=SessionContext(
+                                     session_id=sio_message.get("cid", "klat")),
                                  timing=TimingContext(
                                      client_sent=sio_message.get("timeCreated"))
         )

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -94,15 +94,15 @@ class NeonApiMessage(BaseModel):
         if requested_service == "stt":
             context.destination = ["speech"]
             return NeonGetSTT(data=GetSTTData(**sio_message), context=context,
-                              **mq_context)
+                              **mq_context.model_dump())
         elif requested_service == "tts":
             context.destination = ["audio"]
             return NeonGetTTS(data=GetTTSData(**sio_message), context=context,
-                              **mq_context)
+                              **mq_context.model_dump())
         elif requested_service == "recognizer":
             context.destination = ["skills"]
             return NeonGetResponse(data=GetResponseData(**sio_message),
-                                   context=context, **mq_context)
+                                   context=context, **mq_context.model_dump())
 
 __all__ = [NeonGetTTS.__name__, NeonGetSTT.__name__, NeonGetResponse.__name__,
            NeonApiMessage.__name__]

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -29,7 +29,7 @@ from pydantic import Field, TypeAdapter, model_validator
 
 from neon_data_models.models.base import BaseModel
 from neon_data_models.models.base.contexts import KlatContext, MQContext
-from neon_data_models.models.base.messagebus import MessageContext
+from neon_data_models.models.base.messagebus import BaseMessage, MessageContext
 
 
 class GetTTSData(BaseModel):
@@ -64,19 +64,19 @@ class GetResponseData(BaseModel):
             values['utterances'] = [values.pop('messageText', '')]
         return values
 
-class NeonGetTTS(BaseModel):
+class NeonGetTTS(BaseMessage, MQContext):
+    msg_type: Literal["neon.get_tts"] = "neon.get_tts"
     data: GetTTSData
-    context: MessageContext
 
 
-class NeonGetSTT(BaseModel):
+class NeonGetSTT(BaseMessage, MQContext):
+    msg_type: Literal["neon.get_stt"] = "neon.get_stt"
     data: GetSTTData
-    context: MessageContext
 
 
-class NeonGetResponse(BaseModel):
+class NeonGetResponse(BaseMessage, MQContext):
+    msg_type: Literal["neon.get_response"] = "neon.get_response"
     data: GetResponseData
-    context: MessageContext
 
 
 class NeonApiMessage(BaseModel):
@@ -93,14 +93,16 @@ class NeonApiMessage(BaseModel):
                                  klat_data=klat_context, mq=mq_context)
         if requested_service == "stt":
             context.destination = ["speech"]
-            return NeonGetSTT(data=GetSTTData(**sio_message), context=context)
+            return NeonGetSTT(data=GetSTTData(**sio_message), context=context,
+                              **mq_context)
         elif requested_service == "tts":
             context.destination = ["audio"]
-            return NeonGetTTS(data=GetTTSData(**sio_message), context=context)
+            return NeonGetTTS(data=GetTTSData(**sio_message), context=context,
+                              **mq_context)
         elif requested_service == "recognizer":
             context.destination = ["skills"]
             return NeonGetResponse(data=GetResponseData(**sio_message),
-                                   context=context)
+                                   context=context, **mq_context)
 
 __all__ = [NeonGetTTS.__name__, NeonGetSTT.__name__, NeonGetResponse.__name__,
            NeonApiMessage.__name__]

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -128,9 +128,7 @@ class NeonApiMessage:
         try:
             return cls.ta.validate_python(kwargs)
         except Exception as e:
-            # If validation fails, use the default message type
-            msg_type = kwargs.get('msg_type', 'unknown')
-            print(f"Using default message handler for unsupported type: {msg_type}")
+            # If validation fails, use the default message object
             return NeonMqUnknownMessage(**kwargs)
 
     @staticmethod

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -1,0 +1,99 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2024 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import List, Literal, Optional, Annotated, Union
+from pydantic import Field, TypeAdapter, model_validator
+
+from neon_data_models.models.base import BaseModel
+from neon_data_models.models.base.contexts import KlatContext, MQContext
+from neon_data_models.models.base.messagebus import MessageContext
+
+
+class GetTTSData(BaseModel):
+    text: str = Field(description="Text to be spoken")
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_inputs(cls, values):
+        if 'text' not in values:
+            values['text'] = values.pop('utterance')
+        return values
+
+
+class GetSTTData(BaseModel):
+    audio_data: str = Field(description="Base64-encoded audio data")
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_inputs(cls, values):
+        if 'audio_data' not in values:
+            values['audio_data'] = values.get('message_body')
+        return values
+
+
+class GetResponseData(BaseModel):
+    utterances: List[str] = Field(description="List of input utterance(s)")
+
+class NeonGetTTS(BaseModel):
+    data: GetTTSData
+    context: MessageContext
+
+
+class NeonGetSTT(BaseModel):
+    data: GetSTTData
+    context: MessageContext
+
+
+class NeonGetResponse(BaseModel):
+    data: GetResponseData
+    context: MessageContext
+
+
+class NeonApiMessage(BaseModel):
+    def from_sio_message(sio_message):
+        requested_service = sio_message.get("requested_skill",
+                                         "recognizer").lower()
+        if requested_service not in ["stt", "tts", "recognizer"]:
+            raise ValueError(f"Invalid requested service '{requested_service}'")
+        klat_context = KlatContext(**sio_message)
+        mq_context = MQContext(**sio_message)
+        context = MessageContext(source="mq_api",
+                                 client=sio_message.get("client", "unknown"),
+                                 username=sio_message.get("nick", "guest"),
+                                 klat_data=klat_context, mq=mq_context)
+        if requested_service == "stt":
+            context.destination = ["speech"]
+            return NeonGetSTT(data=GetSTTData(**sio_message), context=context)
+        elif requested_service == "tts":
+            context.destination = ["audio"]
+            return NeonGetTTS(data=GetTTSData(**sio_message), context=context)
+        elif requested_service == "recognizer":
+            context.destination = ["skills"]
+            return NeonGetResponse(data=GetResponseData(**sio_message),
+                                   context=context)
+
+__all__ = [NeonGetTTS.__name__, NeonGetSTT.__name__, NeonGetResponse.__name__,
+           NeonApiMessage.__name__]

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -75,38 +75,58 @@ class GetResponseData(BaseModel):
         return values
 
 class NeonMqGetTts(NeonGetTts, MQContext):
-    pass
+    """
+    Data model for an MQ message requesting TTS synthesis
+    """
 
 
 class NeonMqGetStt(NeonGetStt, MQContext):
-    pass
+    """
+    Data model for an MQ message requesting STT recognition
+    """
+
 
 class NeonMqTextInput(NeonTextInput, MQContext):
-    pass
+    """
+    Data model for an MQ message containing text input
+    """
 
 
 class NeonMqAudioInput(NeonAudioInput, MQContext):
-    pass
+    """
+    Data model for an MQ message containing audio input
+    """
 
 
 class NeonMqSttResponse(NeonSttResponse, MQContext):
-    pass
+    """
+    Data model for an MQ message containing an STT recognition response
+    """
 
 
 class NeonMqTtsResponse(NeonTtsResponse, MQContext):
-    pass
+    """
+    Data model for an MQ message containing a TTS synthesis response
+    """
 
 
 class NeonMqGetLanguages(NeonGetLanguages, MQContext):
-    pass
+    """
+    Data model for an MQ message requesting supported languages
+    """
 
 
 class NeonMqLanguagesResponse(NeonLanguagesResponse, MQContext):
-    pass
+    """
+    Data model for an MQ message containing supported languages response
+    """
 
 
 class NeonMqUnknownMessage(BaseMessage, MQContext):
-    """Default message class for handling unknown message types"""
+    """
+    Default message class for validating Messagebus messages that should be
+    forwarded to an MQ service
+    """
 
 
 class NeonApiMessage:
@@ -164,7 +184,7 @@ class NeonApiMessage:
 
 
 __all__ = [NeonMqGetTts.__name__, NeonMqGetStt.__name__, 
-           NeonMqTextInput.__name__, NeonMqSttResponse.__name__,
-           NeonMqTtsResponse.__name__, NeonMqGetLanguages.__name__,
-           NeonMqLanguagesResponse.__name__, NeonApiMessage.__name__,
-           NeonMqUnknownMessage.__name__]
+           NeonMqTextInput.__name__, NeonMqAudioInput.__name__,
+           NeonMqSttResponse.__name__, NeonMqTtsResponse.__name__,
+           NeonMqGetLanguages.__name__, NeonMqLanguagesResponse.__name__,
+           NeonApiMessage.__name__, NeonMqUnknownMessage.__name__]

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -28,8 +28,9 @@ from typing import List, Literal, Optional, Annotated, Union
 from pydantic import Field, TypeAdapter, model_validator
 
 from neon_data_models.models.base import BaseModel
-from neon_data_models.models.base.contexts import KlatContext, MQContext
+from neon_data_models.models.base.contexts import KlatContext, MQContext, TimingContext
 from neon_data_models.models.base.messagebus import BaseMessage, MessageContext
+from neon_data_models.models.user.database import NeonUserConfig
 
 
 class GetTTSData(BaseModel):
@@ -97,7 +98,11 @@ class NeonApiMessage(BaseModel):
         context = MessageContext(source="mq_api",
                                  client=sio_message.get("client", "unknown"),
                                  username=sio_message.get("nick", "guest"),
-                                 klat_data=klat_context, mq=mq_context)
+                                 klat_data=klat_context, mq=mq_context,
+                                 user_profiles=[NeonUserConfig()],
+                                 timing=TimingContext(
+                                     client_sent=sio_message.get("timeCreated"))
+        )
         if requested_service == "stt":
             context.destination = ["speech"]
             return NeonGetSTT(data=GetSTTData(**sio_message), context=context,

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -105,6 +105,10 @@ class NeonMqLanguagesResponse(NeonLanguagesResponse, MQContext):
     pass
 
 
+class NeonMqUnknownMessage(BaseMessage, MQContext):
+    """Default message class for handling unknown message types"""
+
+
 class NeonApiMessage:
     ta = TypeAdapter(Annotated[Union[NeonMqGetStt, NeonMqGetTts,
                                      NeonMqTextInput, NeonMqSttResponse,
@@ -120,7 +124,14 @@ class NeonApiMessage:
             mq_data = kwargs.get('context', {}).get('mq', {})
             # Update values with MQ context data
             kwargs.update(mq_data)
-        return cls.ta.validate_python(kwargs)
+        
+        try:
+            return cls.ta.validate_python(kwargs)
+        except Exception as e:
+            # If validation fails, use the default message type
+            msg_type = kwargs.get('msg_type', 'unknown')
+            print(f"Using default message handler for unsupported type: {msg_type}")
+            return NeonMqUnknownMessage(**kwargs)
 
     @staticmethod
     def from_sio_message(sio_message: dict) -> BaseMessage:
@@ -157,4 +168,5 @@ class NeonApiMessage:
 __all__ = [NeonMqGetTts.__name__, NeonMqGetStt.__name__, 
            NeonMqTextInput.__name__, NeonMqSttResponse.__name__,
            NeonMqTtsResponse.__name__, NeonMqGetLanguages.__name__,
-           NeonMqLanguagesResponse.__name__, NeonApiMessage.__name__]
+           NeonMqLanguagesResponse.__name__, NeonApiMessage.__name__,
+           NeonMqUnknownMessage.__name__]

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -34,6 +34,8 @@ from neon_data_models.models.base.messagebus import BaseMessage, MessageContext
 
 class GetTTSData(BaseModel):
     text: str = Field(description="Text to be spoken")
+    lang: str = Field(default="en-us",
+                      description="BCP-47 language code for TTS")
 
     @model_validator(mode='before')
     @classmethod
@@ -45,6 +47,8 @@ class GetTTSData(BaseModel):
 
 class GetSTTData(BaseModel):
     audio_data: str = Field(description="Base64-encoded audio data")
+    lang: str = Field(default="en-us",
+                      description="BCP-47 language code for STT")
 
     @model_validator(mode='before')
     @classmethod
@@ -56,6 +60,8 @@ class GetSTTData(BaseModel):
 
 class GetResponseData(BaseModel):
     utterances: List[str] = Field(description="List of input utterance(s)")
+    lang: str = Field(default="en-us",
+                      description="BCP-47 language code for input/response")
 
     @model_validator(mode='before')
     @classmethod
@@ -75,7 +81,8 @@ class NeonGetSTT(BaseMessage, MQContext):
 
 
 class NeonGetResponse(BaseMessage, MQContext):
-    msg_type: Literal["neon.get_response"] = "neon.get_response"
+    # TODO: Should be neon.get_response
+    msg_type: Literal["recognizer_loop:utterance"] = "recognizer_loop:utterance"
     data: GetResponseData
 
 

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -57,6 +57,13 @@ class GetSTTData(BaseModel):
 class GetResponseData(BaseModel):
     utterances: List[str] = Field(description="List of input utterance(s)")
 
+    @model_validator(mode='before')
+    @classmethod
+    def validate_inputs(cls, values):
+        if 'utterances' not in values:
+            values['utterances'] = [values.pop('messageText', '')]
+        return values
+
 class NeonGetTTS(BaseModel):
     data: GetTTSData
     context: MessageContext

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -33,7 +33,7 @@ from neon_data_models.models.base.contexts import KlatContext, MQContext, \
 from neon_data_models.models.base.messagebus import BaseMessage, MessageContext
 from neon_data_models.models.user.database import NeonUserConfig
 from neon_data_models.models.api.messagebus import NeonGetTts, NeonGetStt, \
-    NeonGetResponse, NeonSttResponse, NeonTtsResponse
+    NeonAudioInput, NeonTextInput, NeonSttResponse, NeonTtsResponse
 
 
 class GetTtsData(BaseModel):
@@ -81,7 +81,11 @@ class NeonMqGetTts(NeonGetTts, MQContext):
 class NeonMqGetStt(NeonGetStt, MQContext):
     pass
 
-class NeonMqGetResponse(NeonGetResponse, MQContext):
+class NeonMqTextInput(NeonTextInput, MQContext):
+    pass
+
+
+class NeonMqAudioInput(NeonAudioInput, MQContext):
     pass
 
 
@@ -95,15 +99,22 @@ class NeonMqTtsResponse(NeonTtsResponse, MQContext):
 
 class NeonApiMessage:
     ta = TypeAdapter(Annotated[Union[NeonMqGetStt, NeonMqGetTts,
-                                     NeonMqGetResponse, NeonMqSttResponse,
+                                     NeonMqTextInput, NeonMqSttResponse,
                                      NeonMqTtsResponse],
                                Field(discriminator='msg_type')])
 
     @classmethod
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs) -> BaseMessage:
+        # Parse the MQ Context from a `Message` input to create a proper API message
+        if 'message_id' not in kwargs:
+            # Extract MQ context data from the message
+            mq_data = kwargs.get('context', {}).get('mq', {})
+            # Update values with MQ context data
+            kwargs.update(mq_data)
         return cls.ta.validate_python(kwargs)
 
-    def from_sio_message(sio_message: dict):
+    @staticmethod
+    def from_sio_message(sio_message: dict) -> BaseMessage:
         requested_service = sio_message.get("requested_skill",
                                          "recognizer").lower()
         if requested_service not in ["stt", "tts", "recognizer"]:
@@ -130,17 +141,10 @@ class NeonApiMessage:
                               **mq_context.model_dump())
         elif requested_service == "recognizer":
             context.destination = ["skills"]
-            return NeonMqGetResponse(data=GetResponseData(**sio_message),
+            return NeonMqTextInput(data=GetResponseData(**sio_message),
                                    context=context, **mq_context.model_dump())
-
-    @model_validator(mode='before')
-    @classmethod
-    def parse_from_messagebus(cls, values):
-        # Parse the MQ Context from a `Message` input to 
-        if 'message_id' not in values:
-            values = {**values, **values.get('mq', {})}
 
 
 __all__ = [NeonMqGetTts.__name__, NeonMqGetStt.__name__, 
-           NeonMqGetResponse.__name__, NeonMqSttResponse.__name__,
+           NeonMqTextInput.__name__, NeonMqSttResponse.__name__,
            NeonMqTtsResponse.__name__, NeonApiMessage.__name__]

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -24,16 +24,19 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import List, Literal, Optional, Annotated, Union
+from typing import Annotated, List, Literal, Union
 from pydantic import Field, TypeAdapter, model_validator
 
 from neon_data_models.models.base import BaseModel
-from neon_data_models.models.base.contexts import KlatContext, MQContext, SessionContext, TimingContext
+from neon_data_models.models.base.contexts import KlatContext, MQContext, \
+    SessionContext, TimingContext
 from neon_data_models.models.base.messagebus import BaseMessage, MessageContext
 from neon_data_models.models.user.database import NeonUserConfig
+from neon_data_models.models.api.messagebus import NeonGetTts, NeonGetStt, \
+    NeonGetResponse, NeonSttResponse, NeonTtsResponse
 
 
-class GetTTSData(BaseModel):
+class GetTtsData(BaseModel):
     text: str = Field(description="Text to be spoken")
     lang: str = Field(default="en-us",
                       description="BCP-47 language code for TTS")
@@ -42,11 +45,11 @@ class GetTTSData(BaseModel):
     @classmethod
     def validate_inputs(cls, values):
         if 'text' not in values:
-            values['text'] = values.pop('utterance')
+            values['text'] = values.pop('utterance', None)
         return values
 
 
-class GetSTTData(BaseModel):
+class GetSttData(BaseModel):
     audio_data: str = Field(description="Base64-encoded audio data")
     lang: str = Field(default="en-us",
                       description="BCP-47 language code for STT")
@@ -71,24 +74,36 @@ class GetResponseData(BaseModel):
             values['utterances'] = [values.pop('messageText', '')]
         return values
 
-class NeonGetTTS(BaseMessage, MQContext):
-    msg_type: Literal["neon.get_tts"] = "neon.get_tts"
-    data: GetTTSData
+class NeonMqGetTts(NeonGetTts, MQContext):
+    pass
 
 
-class NeonGetSTT(BaseMessage, MQContext):
-    msg_type: Literal["neon.get_stt"] = "neon.get_stt"
-    data: GetSTTData
+class NeonMqGetStt(NeonGetStt, MQContext):
+    pass
+
+class NeonMqGetResponse(NeonGetResponse, MQContext):
+    pass
 
 
-class NeonGetResponse(BaseMessage, MQContext):
-    # TODO: Should be neon.get_response
-    msg_type: Literal["recognizer_loop:utterance"] = "recognizer_loop:utterance"
-    data: GetResponseData
+class NeonMqSttResponse(NeonSttResponse, MQContext):
+    pass
 
 
-class NeonApiMessage(BaseModel):
-    def from_sio_message(sio_message):
+class NeonMqTtsResponse(NeonTtsResponse, MQContext):
+    pass
+
+
+class NeonApiMessage:
+    ta = TypeAdapter(Annotated[Union[NeonMqGetStt, NeonMqGetTts,
+                                     NeonMqGetResponse, NeonMqSttResponse,
+                                     NeonMqTtsResponse],
+                               Field(discriminator='msg_type')])
+
+    @classmethod
+    def __new__(cls, *args, **kwargs):
+        return cls.ta.validate_python(kwargs)
+
+    def from_sio_message(sio_message: dict):
         requested_service = sio_message.get("requested_skill",
                                          "recognizer").lower()
         if requested_service not in ["stt", "tts", "recognizer"]:
@@ -107,16 +122,25 @@ class NeonApiMessage(BaseModel):
         )
         if requested_service == "stt":
             context.destination = ["speech"]
-            return NeonGetSTT(data=GetSTTData(**sio_message), context=context,
+            return NeonMqGetStt(data=GetSttData(**sio_message), context=context,
                               **mq_context.model_dump())
         elif requested_service == "tts":
             context.destination = ["audio"]
-            return NeonGetTTS(data=GetTTSData(**sio_message), context=context,
+            return NeonMqGetTts(data=GetTtsData(**sio_message), context=context,
                               **mq_context.model_dump())
         elif requested_service == "recognizer":
             context.destination = ["skills"]
-            return NeonGetResponse(data=GetResponseData(**sio_message),
+            return NeonMqGetResponse(data=GetResponseData(**sio_message),
                                    context=context, **mq_context.model_dump())
 
-__all__ = [NeonGetTTS.__name__, NeonGetSTT.__name__, NeonGetResponse.__name__,
-           NeonApiMessage.__name__]
+    @model_validator(mode='before')
+    @classmethod
+    def parse_from_messagebus(cls, values):
+        # Parse the MQ Context from a `Message` input to 
+        if 'message_id' not in values:
+            values = {**values, **values.get('mq', {})}
+
+
+__all__ = [NeonMqGetTts.__name__, NeonMqGetStt.__name__, 
+           NeonMqGetResponse.__name__, NeonMqSttResponse.__name__,
+           NeonMqTtsResponse.__name__, NeonApiMessage.__name__]

--- a/neon_data_models/models/api/mq/users.py
+++ b/neon_data_models/models/api/mq/users.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/api/node_v1/__init__.py
+++ b/neon_data_models/models/api/node_v1/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/base/__init__.py
+++ b/neon_data_models/models/base/__init__.py
@@ -25,9 +25,28 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from os import environ
+from datetime import datetime, timedelta
 from pydantic import ConfigDict, BaseModel as _BaseModel
 
 
 class BaseModel(_BaseModel):
     model_config = ConfigDict(extra="allow" if environ.get(
             "NEON_DATA_MODELS_ALLOW_EXTRA", "false") != "false" else "ignore")
+
+        
+    def model_dump(self, *args, **kwargs) -> dict:
+        """
+        Global `model_dump` overrides to ensure model serialization.
+        """
+        data = super().model_dump(*args, **kwargs)
+        
+        # Convert datetime objects to timestamps and timedelta to seconds
+        for field, value in list(data.items()):
+            if isinstance(value, datetime):
+                data[field] = value.timestamp()
+            elif isinstance(value, timedelta):
+                data[field] = value.total_seconds()
+        
+        return data
+
+

--- a/neon_data_models/models/base/__init__.py
+++ b/neon_data_models/models/base/__init__.py
@@ -37,16 +37,31 @@ class BaseModel(_BaseModel):
     def model_dump(self, *args, **kwargs) -> dict:
         """
         Global `model_dump` overrides to ensure model serialization.
+        Recursively processes nested dictionaries, lists, and BaseModel instances.
         """
         data = super().model_dump(*args, **kwargs)
-        
-        # Convert datetime objects to timestamps and timedelta to seconds
-        for field, value in list(data.items()):
-            if isinstance(value, datetime):
-                data[field] = value.timestamp()
-            elif isinstance(value, timedelta):
-                data[field] = value.total_seconds()
-        
-        return data
+        return self._process_data(data)
+    
+    def _process_data(self, data):
+        """
+        Recursively process data to convert datetime and timedelta objects.
+        """
+        if isinstance(data, dict):
+            # Process dictionary values
+            for key, value in list(data.items()):
+                data[key] = self._process_data(value)
+            return data
+        elif isinstance(data, list):
+            # Process list elements
+            return [self._process_data(item) for item in data]
+        elif isinstance(data, datetime):
+            # Convert datetime to timestamp
+            return data.timestamp()
+        elif isinstance(data, timedelta):
+            # Convert timedelta to seconds
+            return data.total_seconds()
+        else:
+            # Return other types unchanged
+            return data
 
 

--- a/neon_data_models/models/base/__init__.py
+++ b/neon_data_models/models/base/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -24,7 +24,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Literal, List, Optional, Any, Tuple
 
 from pydantic import Field, model_validator
@@ -88,42 +88,34 @@ class TimingContext(BaseModel):
     transform_audio: Optional[timedelta] = None
     transform_utterance: Optional[timedelta] = None
     wait_in_queue: Optional[timedelta] = None
-    
+
     @model_validator(mode='before')
     @classmethod
-    def convert_timestamps(cls, data):
-        if not isinstance(data, dict):
-            return data
-        
+    def validate_datetime_fields(cls, values):
+        """
+        Validate datetime fields to parse epoch timestamps into datetime objects.
+        Dynamically identifies fields with datetime type annotations.
+        """
+        # Find all fields that have datetime type annotation
         datetime_fields = [
-            'audio_begin', 'audio_end', 'client_sent', 'gradio_sent',
-            'handle_utterance', 'response_sent', 'speech_start'
-        ]
-        
-        timedelta_fields = [
-            'get_stt', 'get_tts', 'iris_input_handling', 'mq_response_handler',
-            'mq_from_core', 'mq_from_client', 'mq_input_handler', 'client_to_core',
-            'client_from_core', 'save_transcript', 'transform_audio',
-            'transform_utterance', 'wait_in_queue'
+            field_name for field_name, field_info in cls.model_fields.items()
+            if field_info.annotation == datetime or (
+                hasattr(field_info.annotation, "__origin__") and 
+                field_info.annotation.__origin__ is Optional and 
+                datetime in field_info.annotation.__args__
+            )
         ]
         
         for field in datetime_fields:
-            if field in data and data[field] is not None and not isinstance(data[field], datetime):
-                try:
-                    data[field] = datetime.fromtimestamp(float(data[field]))
-                except (ValueError, TypeError):
-                    # Leave it as is if conversion fails, let pydantic handle validation
-                    pass
+            if field in values and values[field] is not None:
+                if isinstance(values[field], (int, float)):
+                    # Convert epoch timestamp to datetime with UTC timezone
+                    values[field] = datetime.fromtimestamp(values[field], tz=timezone.utc)
+                elif not isinstance(values[field], datetime):
+                    # If it's neither a timestamp nor a datetime, raise an error
+                    raise ValueError(f"Field '{field}' must be a timestamp or datetime object")
         
-        for field in timedelta_fields:
-            if field in data and data[field] is not None and not isinstance(data[field], timedelta):
-                try:
-                    data[field] = timedelta(seconds=float(data[field]))
-                except (ValueError, TypeError):
-                    # Leave it as is if conversion fails, let pydantic handle validation
-                    pass
-        
-        return data
+        return values
 
 
 class KlatContext(BaseModel):

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -130,7 +130,7 @@ class KlatContext(BaseModel):
         """
         Validate KlatContext inputs to normalize messageID to sid.
         """
-        if "sid" not in values:
+        if "sid" not in values and "messageID" in values:
             values["sid"] = values.get("messageID")
         return values
 

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -127,8 +127,8 @@ class TimingContext(BaseModel):
 
 
 class KlatContext(BaseModel):
-    sid: str
-    cid: str
+    sid: str = ""
+    cid: str = ""
     title: Optional[str] = ""
 
     @model_validator(mode='before')

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -25,7 +25,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from datetime import datetime, timedelta
-from typing import Literal, List, Optional
+from typing import Literal, List, Optional, Any
 
 from pydantic import model_validator
 
@@ -87,18 +87,6 @@ class TimingContext(BaseModel):
     transform_utterance: Optional[timedelta] = None
     wait_in_queue: Optional[timedelta] = None
     
-    def model_dump(self, *args, **kwargs) -> dict:
-        data = super().model_dump(*args, **kwargs)
-        
-        # Convert datetime objects to timestamps and timedelta to seconds
-        for field, value in list(data.items()):
-            if isinstance(value, datetime):
-                data[field] = value.timestamp()
-            elif isinstance(value, timedelta):
-                data[field] = value.total_seconds()
-        
-        return data
-
     @model_validator(mode='before')
     @classmethod
     def convert_timestamps(cls, data):

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -27,6 +27,8 @@
 from datetime import datetime, timedelta
 from typing import Literal, List, Optional
 
+from pydantic import model_validator
+
 from neon_data_models.models.base import BaseModel
 
 
@@ -95,3 +97,13 @@ class KlatContext(BaseModel):
 class MQContext(BaseModel):
     routing_key: Optional[str] = None
     message_id: str
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_inputs(cls, values):
+        """
+        Validate MQContext inputs to normalize messageID to message_id.
+        """
+        if not values.get("message_id"):
+            values["message_id"] = values.get("messageID")
+        return values

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -135,7 +135,7 @@ class KlatContext(BaseModel):
         """
         Validate KlatContext inputs to normalize messageID to sid.
         """
-        if not values.get("sid"):
+        if "sid" not in values:
             values["sid"] = values.get("messageID")
         return values
 
@@ -149,6 +149,6 @@ class MQContext(BaseModel):
         """
         Validate MQContext inputs to normalize messageID to message_id.
         """
-        if not values.get("message_id"):
+        if "message_id" not in values:
             values["message_id"] = values.get("messageID")
         return values

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -119,9 +119,10 @@ class TimingContext(BaseModel):
 
 
 class KlatContext(BaseModel):
-    sid: str = ""
-    cid: str = ""
-    title: Optional[str] = ""
+    sid: str = Field(default="", description="Klat Shout ID")
+    cid: str = Field(default="", description="Klat Conversation ID")
+    title: Optional[str] = Field(default="",
+                                  description="Klat Conversation Title")
 
     @model_validator(mode='before')
     @classmethod

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -25,16 +25,18 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from datetime import datetime, timedelta
-from typing import Literal, List, Optional, Any
+from typing import Literal, List, Optional, Any, Tuple
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 
 from neon_data_models.models.base import BaseModel
 
 
 class SessionContext(BaseModel):
     session_id: str = "default"
-    active_skills: List[str] = []
+    active_skills: List[Tuple[str, float]] = Field(
+        default=[], 
+        description="List of tuple `skill_id` and last used timestamp")
     utterance_states: dict = {}
     lang: Optional[str] = None
     context: dict = {}

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -93,6 +93,15 @@ class KlatContext(BaseModel):
     cid: str
     title: Optional[str] = ""
 
+    @model_validator(mode='before')
+    @classmethod
+    def validate_inputs(cls, values):
+        """
+        Validate KlatContext inputs to normalize messageID to sid.
+        """
+        if not values.get("sid"):
+            values["sid"] = values.get("messageID")
+        return values
 
 class MQContext(BaseModel):
     routing_key: Optional[str] = None

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -121,7 +121,7 @@ class TimingContext(BaseModel):
 class KlatContext(BaseModel):
     sid: str = Field(default="", description="Klat Shout ID")
     cid: str = Field(default="", description="Klat Conversation ID")
-    title: Optional[str] = Field(default="",
+    title: str = Field(default="",
                                   description="Klat Conversation Title")
 
     @model_validator(mode='before')
@@ -130,8 +130,9 @@ class KlatContext(BaseModel):
         """
         Validate KlatContext inputs to normalize messageID to sid.
         """
-        if "sid" not in values and "messageID" in values:
-            values["sid"] = values.get("messageID")
+        values.setdefault("sid", values.get("messageID", ""))
+        if "title" in values and values["title"] is None:
+            values.pop("title")
         return values
 
 class MQContext(BaseModel):
@@ -144,6 +145,5 @@ class MQContext(BaseModel):
         """
         Validate MQContext inputs to normalize messageID to message_id.
         """
-        if "message_id" not in values:
-            values["message_id"] = values.get("messageID")
+        values.setdefault("message_id", values.get("messageID"))
         return values

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -121,8 +121,7 @@ class TimingContext(BaseModel):
 class KlatContext(BaseModel):
     sid: str = Field(default="", description="Klat Shout ID")
     cid: str = Field(default="", description="Klat Conversation ID")
-    title: str = Field(default="",
-                                  description="Klat Conversation Title")
+    title: str = Field(default="", description="Klat Conversation Title")
 
     @model_validator(mode='before')
     @classmethod

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -86,6 +86,54 @@ class TimingContext(BaseModel):
     transform_audio: Optional[timedelta] = None
     transform_utterance: Optional[timedelta] = None
     wait_in_queue: Optional[timedelta] = None
+    
+    def model_dump(self, *args, **kwargs) -> dict:
+        data = super().model_dump(*args, **kwargs)
+        
+        # Convert datetime objects to timestamps and timedelta to seconds
+        for field, value in list(data.items()):
+            if isinstance(value, datetime):
+                data[field] = value.timestamp()
+            elif isinstance(value, timedelta):
+                data[field] = value.total_seconds()
+        
+        return data
+
+    @model_validator(mode='before')
+    @classmethod
+    def convert_timestamps(cls, data):
+        if not isinstance(data, dict):
+            return data
+        
+        datetime_fields = [
+            'audio_begin', 'audio_end', 'client_sent', 'gradio_sent',
+            'handle_utterance', 'response_sent', 'speech_start'
+        ]
+        
+        timedelta_fields = [
+            'get_stt', 'get_tts', 'iris_input_handling', 'mq_response_handler',
+            'mq_from_core', 'mq_from_client', 'mq_input_handler', 'client_to_core',
+            'client_from_core', 'save_transcript', 'transform_audio',
+            'transform_utterance', 'wait_in_queue'
+        ]
+        
+        for field in datetime_fields:
+            if field in data and data[field] is not None and not isinstance(data[field], datetime):
+                try:
+                    data[field] = datetime.fromtimestamp(float(data[field]))
+                except (ValueError, TypeError):
+                    # Leave it as is if conversion fails, let pydantic handle validation
+                    pass
+        
+        for field in timedelta_fields:
+            if field in data and data[field] is not None and not isinstance(data[field], timedelta):
+                try:
+                    data[field] = timedelta(seconds=float(data[field]))
+                except (ValueError, TypeError):
+                    # Leave it as is if conversion fails, let pydantic handle validation
+                    pass
+        
+        return data
 
 
 class KlatContext(BaseModel):

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -74,7 +74,7 @@ class BaseMessage(BaseModel):
     data: dict
     context: MessageContext
 
-    def as_message(self) -> "Message":
+    def as_message(self) -> "Message": # type: ignore
         """
         Get a `Message` representation of this object.
         """

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -25,7 +25,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from typing import Optional, List, Union
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 
 from neon_data_models.models.base import BaseModel
 from neon_data_models.models.base.contexts import (SessionContext, KlatContext,
@@ -67,6 +67,12 @@ class MessageContext(BaseModel):
         if isinstance(v, str):
             return [v]
         return v
+    
+    @model_validator(mode='before')
+    def validate_session_value(cls, data):
+        if isinstance(data, dict) and data.get('session', {}) is None:
+            data.pop('session')
+        return data
 
 
 class BaseMessage(BaseModel):

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -64,3 +64,11 @@ class BaseMessage(BaseModel):
     msg_type: str
     data: dict
     context: MessageContext
+
+    def as_message(self):
+        try:
+            from ovos_bus_client.message import Message
+            return Message(self.msg_type, self.data, self.context.model_dump())
+        except ImportError:
+            raise RuntimeError("pip install ovos-bus-client to enable Message "
+                               "deserialization.")

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -39,8 +39,9 @@ class MessageContext(BaseModel):
     session: Optional[SessionContext] = Field(description="Session Data",
                                               default=None)
     node_data: Optional[NodeData] = Field(description="Node Data", default=None)
-    timing: Optional[TimingContext] = Field(
-        description="User Interaction Timing Information", default=None)
+    timing: TimingContext = Field(
+        description="User Interaction Timing Information", 
+        default=TimingContext())
     user_profiles: Optional[List[NeonUserConfig]] = (
         Field(description="List of relevant user profiles", default=None))
     klat_data: Optional[KlatContext] = Field(

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -64,6 +64,14 @@ class BaseMessage(BaseModel):
     msg_type: str
     data: dict
     context: MessageContext
+    
+    @classmethod
+    def model_validate(cls, obj, *args, **kwargs):
+        """Normalize message inputs that use 'type' instead of 'msg_type'."""
+        if isinstance(obj, dict) and "type" in obj and "msg_type" not in obj:
+            obj = obj.copy()
+            obj["msg_type"] = obj.pop("type")
+        return BaseMessage.model_validate(cls, obj, *args, **kwargs)
 
     def as_message(self):
         try:

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -64,14 +64,6 @@ class BaseMessage(BaseModel):
     msg_type: str
     data: dict
     context: MessageContext
-    
-    @classmethod
-    def model_validate(cls, obj, *args, **kwargs):
-        """Normalize message inputs that use 'type' instead of 'msg_type'."""
-        if isinstance(obj, dict) and "type" in obj and "msg_type" not in obj:
-            obj = obj.copy()
-            obj["msg_type"] = obj.pop("type")
-        return BaseMessage.model_validate(cls, obj, *args, **kwargs)
 
     def as_message(self):
         try:

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -68,7 +68,11 @@ class BaseMessage(BaseModel):
     def as_message(self):
         try:
             from ovos_bus_client.message import Message
-            return Message(self.msg_type, self.data, self.context.model_dump())
+            if hasattr(self.data, 'model_dump'):
+                data = self.data.model_dump()
+            else:
+                data = self.data
+            return Message(self.msg_type, data, self.context.model_dump())
         except ImportError:
             raise RuntimeError("pip install ovos-bus-client to enable Message "
                                "deserialization.")

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -74,7 +74,7 @@ class BaseMessage(BaseModel):
     data: dict
     context: MessageContext
 
-    def as_message(self) -> "Message": # type: ignore
+    def as_messagebus_message(self) -> "Message": # type: ignore
         """
         Get a `Message` representation of this object.
         """

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -25,7 +25,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from typing import Optional, List, Union
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, field_validator
 
 from neon_data_models.models.base import BaseModel
 from neon_data_models.models.base.contexts import (SessionContext, KlatContext,
@@ -56,8 +56,17 @@ class MessageContext(BaseModel):
     client_name: str = "unknown"
     client: str = "unknown"
     source: Union[str, List[str]] = "unknown"
-    destination: List[str] = ["skills"]
+    destination: Union[str, List[str]] = Field(
+        default=["skills"],
+        description="List of destination modules expected to handle the message"
+        )
     neon_should_respond: bool = True
+    
+    @field_validator('destination')
+    def validate_destination(cls, v):
+        if isinstance(v, str):
+            return [v]
+        return v
 
 
 class BaseMessage(BaseModel):

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -74,7 +74,10 @@ class BaseMessage(BaseModel):
     data: dict
     context: MessageContext
 
-    def as_message(self):
+    def as_message(self) -> "Message":
+        """
+        Get a `Message` representation of this object.
+        """
         try:
             from ovos_bus_client.message import Message
             if hasattr(self.data, 'model_dump'):

--- a/neon_data_models/models/client/__init__.py
+++ b/neon_data_models/models/client/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/client/node.py
+++ b/neon_data_models/models/client/node.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/user/__init__.py
+++ b/neon_data_models/models/user/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/user/database.py
+++ b/neon_data_models/models/user/database.py
@@ -31,7 +31,7 @@ from uuid import uuid4
 
 # from neon_data_models.models.api import HanaToken
 from neon_data_models.models.base import BaseModel
-from pydantic import Field
+from pydantic import Field, field_validator
 from datetime import date
 
 from neon_data_models.enum import AccessRoles
@@ -49,6 +49,14 @@ class _UserConfig(BaseModel):
                                         "(i.e. `https://example.com/avatar.jpg")
     about: str = ""
     phone: str = ""
+    
+    @field_validator('dob', mode='before')
+    @classmethod
+    def validate_dob(cls, v):
+        if v == "YYYY/MM/DD":
+            # Legacy default value for dob should be treated as `None`
+            return None
+        return v
 
 
 class _LanguageConfig(BaseModel):
@@ -197,7 +205,7 @@ class User(BaseModel):
     klat: KlatConfig = KlatConfig()
     llm: BrainForgeConfig = BrainForgeConfig()
     permissions: PermissionsConfig = PermissionsConfig()
-    tokens: Optional[List['HanaToken']] = []
+    tokens: Optional[List['HanaToken']] = [] # type: ignore
 
     def __eq__(self, other):
         return self.model_dump() == other.model_dump()

--- a/neon_data_models/models/user/neon_profile.py
+++ b/neon_data_models/models/user/neon_profile.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/types.py
+++ b/neon_data_models/types.py
@@ -27,4 +27,4 @@
 from typing import Literal
 
 
-gender = Literal["male", "female"]
+Gender = Literal["male", "female"]

--- a/neon_data_models/types.py
+++ b/neon_data_models/types.py
@@ -24,43 +24,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Optional, List, Union
-from pydantic import ConfigDict, Field
-
-from neon_data_models.models.base import BaseModel
-from neon_data_models.models.base.contexts import (SessionContext, KlatContext,
-                                                   TimingContext, MQContext)
-from neon_data_models.models.client.node import NodeData
-from neon_data_models.models.user.database import NeonUserConfig
+from typing import Literal
 
 
-class MessageContext(BaseModel):
-    model_config = ConfigDict(extra="allow")
-    session: SessionContext = Field(description="Session Data",
-                                              default=SessionContext())
-    node_data: Optional[NodeData] = Field(description="Node Data", default=None)
-    timing: TimingContext = Field(
-        description="User Interaction Timing Information", 
-        default=TimingContext())
-    user_profiles: Optional[List[NeonUserConfig]] = (
-        Field(description="List of relevant user profiles", default=None))
-    klat_data: Optional[KlatContext] = Field(
-        description="Klat context for Klat-generated messages", default=None)
-    mq: Optional[MQContext] = Field(
-        description="MQ context for messages traversing a RabbitMQ broker",
-        default=None)
-
-    username: str = "local"
-    # TODO: Consider refactoring client/client_name into a single dict
-    #  or merging with `node_data`
-    client_name: str = "unknown"
-    client: str = "unknown"
-    source: Union[str, List[str]] = "unknown"
-    destination: List[str] = ["skills"]
-    neon_should_respond: bool = True
-
-
-class BaseMessage(BaseModel):
-    msg_type: str
-    data: dict
-    context: MessageContext
+gender = Literal["male", "female"]

--- a/neon_data_models/types.py
+++ b/neon_data_models/types.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/util.py
+++ b/neon_data_models/util.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/version.py
+++ b/neon_data_models/version.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,1 +1,2 @@
 pytest
+ovos-bus-client~=0.1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2022 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License

--- a/tests/models/api/test_llm.py
+++ b/tests/models/api/test_llm.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -69,6 +69,38 @@ class TestMessagebusModels(TestCase):
         self.assertEqual(tts_response.genders, ["female", "male"])
         self.assertEqual(tts_response.audio["female"], "base64audio1")
         self.assertEqual(tts_response.audio["male"], "base64audio2")
+        
+        # Test default values for male and female fields
+        self.assertIsNone(tts_response.male)
+        self.assertIsNone(tts_response.female)
+
+        # Test with explicit male and female fields
+        valid_response_with_gender_paths = {
+            "sentence": "Hello world",
+            "translated": False,
+            "genders": ["female", "male"],
+            "audio": {"female": "base64audio1", "male": "base64audio2"},
+            "male": "/path/to/male.wav",
+            "female": "/path/to/female.wav"
+        }
+        tts_response_with_gender_paths = TtsResponse(**valid_response_with_gender_paths)
+        self.assertEqual(tts_response_with_gender_paths.male, "/path/to/male.wav")
+        self.assertEqual(tts_response_with_gender_paths.female, "/path/to/female.wav")
+        
+        # Test with different content in audio dict vs direct fields
+        mixed_response = {
+            "sentence": "Hello world",
+            "translated": False,
+            "genders": ["female", "male"],
+            "audio": {"female": "base64audio1", "male": "base64audio2"},
+            "male": "/path/to/different_male.wav",
+            "female": "/path/to/different_female.wav"
+        }
+        mixed_tts_response = TtsResponse(**mixed_response)
+        self.assertEqual(mixed_tts_response.audio["male"], "base64audio2")
+        self.assertEqual(mixed_tts_response.male, "/path/to/different_male.wav")
+        self.assertEqual(mixed_tts_response.audio["female"], "base64audio1")
+        self.assertEqual(mixed_tts_response.female, "/path/to/different_female.wav")
 
         # Test valid response data without phonemes
         valid_response_no_phonemes = {

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -218,7 +218,7 @@ class TestMessagebusModels(TestCase):
         message_empty_dest = NeonGetTts(data=data, context=empty_dest_context)
         self.assertIn("audio", message_empty_dest.context.destination)
         
-        other_dest_context = {"destination": ["skills"]}
+        other_dest_context = {"destination": ["skills", "audio"]}
         message_other_dest = NeonGetTts(data=data, context=other_dest_context)
         self.assertIn("audio", message_other_dest.context.destination)
         self.assertIn("skills", message_other_dest.context.destination)
@@ -249,7 +249,7 @@ class TestMessagebusModels(TestCase):
         message_empty_dest = NeonGetStt(data=data, context=empty_dest_context)
         self.assertIn("audio", message_empty_dest.context.destination)
         
-        other_dest_context = {"destination": ["skills"]}
+        other_dest_context = {"destination": ["skills", "audio"]}
         message_other_dest = NeonGetStt(data=data, context=other_dest_context)
         self.assertIn("audio", message_other_dest.context.destination)
         self.assertIn("skills", message_other_dest.context.destination)
@@ -360,7 +360,7 @@ class TestMessagebusModels(TestCase):
         message_empty_dest = NeonAudioInput(data=data, context=empty_dest_context)
         self.assertIn("audio", message_empty_dest.context.destination)
         
-        other_dest_context = {"destination": ["skills"]}
+        other_dest_context = {"destination": ["skills", "audio"]}
         message_other_dest = NeonAudioInput(data=data, context=other_dest_context)
         self.assertIn("audio", message_other_dest.context.destination)
         self.assertIn("skills", message_other_dest.context.destination)

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -289,3 +289,65 @@ class TestMessagebusModels(TestCase):
         # Test missing required fields
         with self.assertRaises(ValidationError):
             NeonAudioInput(message_id=message_id, context={})  # Missing data
+
+    def test_neon_languages_data(self):
+        from neon_data_models.models.api.messagebus import NeonLanguagesData
+
+        # Test valid data
+        valid_data = {
+            "stt": ["en-us", "es-es", "fr-fr"],
+            "tts": ["en-us", "es-es"],
+            "skills": ["en-us"]
+        }
+        languages_data = NeonLanguagesData(**valid_data)
+        self.assertIsInstance(languages_data, NeonLanguagesData)
+        self.assertEqual(languages_data.stt, ["en-us", "es-es", "fr-fr"])
+        self.assertEqual(languages_data.tts, ["en-us", "es-es"])
+        self.assertEqual(languages_data.skills, ["en-us"])
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            NeonLanguagesData(stt=["en-us"], tts=["en-us"])  # Missing skills
+
+        with self.assertRaises(ValidationError):
+            NeonLanguagesData(stt=["en-us"], skills=["en-us"])  # Missing tts
+
+        with self.assertRaises(ValidationError):
+            NeonLanguagesData(tts=["en-us"], skills=["en-us"])  # Missing stt
+
+    def test_neon_get_languages(self):
+        from neon_data_models.models.api.messagebus import NeonGetLanguages
+        from neon_data_models.models.base.messagebus import BaseMessage
+
+        # Test valid message
+        valid_message = NeonGetLanguages(data={}, context={})
+        self.assertIsInstance(valid_message, NeonGetLanguages)
+        self.assertIsInstance(valid_message, BaseMessage)
+        self.assertEqual(valid_message.msg_type, "neon.languages.get")
+
+        # Test with invalid msg_type
+        with self.assertRaises(ValidationError):
+            message_with_id = NeonGetLanguages(msg_type="test_mid",
+                                               data={}, context={})
+
+    def test_neon_languages_response(self):
+        from neon_data_models.models.api.messagebus import NeonLanguagesResponse, NeonLanguagesData
+        from neon_data_models.models.base.messagebus import BaseMessage
+
+        # Test valid message
+        languages_data = NeonLanguagesData(
+            stt=["en-us", "es-es"],
+            tts=["en-us", "fr-fr"],
+            skills=["en-us"]
+        )
+        valid_message = NeonLanguagesResponse(data=languages_data, context={})
+        self.assertIsInstance(valid_message, NeonLanguagesResponse)
+        self.assertIsInstance(valid_message, BaseMessage)
+        self.assertEqual(valid_message.msg_type, "neon.languages.get.response")
+        self.assertEqual(valid_message.data.stt, ["en-us", "es-es"])
+        self.assertEqual(valid_message.data.tts, ["en-us", "fr-fr"])
+        self.assertEqual(valid_message.data.skills, ["en-us"])
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            NeonLanguagesResponse(context={})  # Missing data

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -212,6 +212,20 @@ class TestMessagebusModels(TestCase):
         self.assertIsInstance(valid_message, BaseMessage)
         self.assertEqual(valid_message.data.text, "Hello world")
         self.assertEqual(valid_message.msg_type, "neon.get_tts")
+        
+        # Test ensure_audio_destination validator
+        empty_dest_context = {"destination": []}
+        message_empty_dest = NeonGetTts(data=data, context=empty_dest_context)
+        self.assertIn("audio", message_empty_dest.context.destination)
+        
+        other_dest_context = {"destination": ["skills"]}
+        message_other_dest = NeonGetTts(data=data, context=other_dest_context)
+        self.assertIn("audio", message_other_dest.context.destination)
+        self.assertIn("skills", message_other_dest.context.destination)
+        
+        audio_dest_context = {"destination": ["audio"]}
+        message_audio_dest = NeonGetTts(data=data, context=audio_dest_context)
+        self.assertEqual(message_audio_dest.context.destination, ["audio"])
 
         # Test missing required fields
         with self.assertRaises(ValidationError):
@@ -229,6 +243,20 @@ class TestMessagebusModels(TestCase):
         self.assertIsInstance(valid_message, BaseMessage)
         self.assertEqual(valid_message.data.audio_data, "base64encodedstring")
         self.assertEqual(valid_message.msg_type, "neon.get_stt")
+        
+        # Test ensure_audio_destination validator
+        empty_dest_context = {"destination": []}
+        message_empty_dest = NeonGetStt(data=data, context=empty_dest_context)
+        self.assertIn("audio", message_empty_dest.context.destination)
+        
+        other_dest_context = {"destination": ["skills"]}
+        message_other_dest = NeonGetStt(data=data, context=other_dest_context)
+        self.assertIn("audio", message_other_dest.context.destination)
+        self.assertIn("skills", message_other_dest.context.destination)
+        
+        audio_dest_context = {"destination": ["audio"]}
+        message_audio_dest = NeonGetStt(data=data, context=audio_dest_context)
+        self.assertEqual(message_audio_dest.context.destination, ["audio"])
 
         # Test missing required fields
         with self.assertRaises(ValidationError):
@@ -246,6 +274,20 @@ class TestMessagebusModels(TestCase):
         self.assertIsInstance(valid_message, BaseMessage)
         self.assertEqual(valid_message.data.utterances, ["How are you?"])
         self.assertEqual(valid_message.msg_type, "recognizer_loop:utterance")
+        
+        # Test ensure_skills_destination validator
+        empty_dest_context = {"destination": []}
+        message_empty_dest = NeonTextInput(data=data, context=empty_dest_context)
+        self.assertIn("skills", message_empty_dest.context.destination)
+        
+        other_dest_context = {"destination": ["audio"]}
+        message_other_dest = NeonTextInput(data=data, context=other_dest_context)
+        self.assertIn("skills", message_other_dest.context.destination)
+        self.assertIn("audio", message_other_dest.context.destination)
+        
+        skills_dest_context = {"destination": ["skills"]}
+        message_skills_dest = NeonTextInput(data=data, context=skills_dest_context)
+        self.assertEqual(message_skills_dest.context.destination, ["skills"])
 
         # Test missing required fields
         with self.assertRaises(ValidationError):
@@ -312,6 +354,20 @@ class TestMessagebusModels(TestCase):
         self.assertEqual(valid_message.data.audio_data, "base64encodedstring")
         self.assertEqual(valid_message.data.lang, "en-us")  # Default value
         self.assertEqual(valid_message.msg_type, "neon.audio_input")
+        
+        # Test ensure_audio_destination validator
+        empty_dest_context = {"destination": []}
+        message_empty_dest = NeonAudioInput(data=data, context=empty_dest_context)
+        self.assertIn("audio", message_empty_dest.context.destination)
+        
+        other_dest_context = {"destination": ["skills"]}
+        message_other_dest = NeonAudioInput(data=data, context=other_dest_context)
+        self.assertIn("audio", message_other_dest.context.destination)
+        self.assertIn("skills", message_other_dest.context.destination)
+        
+        audio_dest_context = {"destination": ["audio"]}
+        message_audio_dest = NeonAudioInput(data=data, context=audio_dest_context)
+        self.assertEqual(message_audio_dest.context.destination, ["audio"])
 
         # Test with message_body instead of audio_data (backward compatibility)
         compat_data = GetSttData(message_body="different_base64string")

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -51,34 +51,42 @@ class TestMessagebusModels(TestCase):
 
     def test_tts_response_data(self):
         from neon_data_models.models.api.messagebus import TtsResponse, TtsReponseData
+        from neon_data_models.types import Gender
 
         # Test valid response data
         valid_response = {
             "sentence": "Hello world",
             "translated": False,
-            "phonemes": "HH AH L OW W ER L D"
+            "phonemes": "HH AH L OW W ER L D",
+            "genders": ["female", "male"],
+            "audio": {"female": "base64audio1", "male": "base64audio2"}
         }
         tts_response = TtsResponse(**valid_response)
         self.assertIsInstance(tts_response, TtsResponse)
         self.assertEqual(tts_response.sentence, "Hello world")
         self.assertEqual(tts_response.translated, False)
         self.assertEqual(tts_response.phonemes, "HH AH L OW W ER L D")
+        self.assertEqual(tts_response.genders, ["female", "male"])
+        self.assertEqual(tts_response.audio["female"], "base64audio1")
+        self.assertEqual(tts_response.audio["male"], "base64audio2")
 
         # Test valid responses data
         valid_responses_data = {
             "responses": {
-                "en-us": {
-                    "female": valid_response
-                }
+                "en-us": tts_response
             }
         }
         tts_responses = TtsReponseData(**valid_responses_data)
         self.assertIsInstance(tts_responses, TtsReponseData)
-        self.assertEqual(tts_responses.responses["en-us"]["female"].sentence, "Hello world")
+        self.assertEqual(tts_responses.responses["en-us"].sentence, "Hello world")
+        self.assertEqual(tts_responses.responses["en-us"].genders, ["female", "male"])
 
         # Test missing required fields
         with self.assertRaises(ValidationError):
-            TtsResponse(sentence="Hello", phonemes="HH AH L OW")  # Missing translated
+            TtsResponse(sentence="Hello", phonemes="HH AH L OW", translated=False)  # Missing genders and audio
+        
+        with self.assertRaises(ValidationError):
+            TtsResponse(sentence="Hello", phonemes="HH AH L OW", translated=False, genders=["female"])  # Missing audio
         
         with self.assertRaises(ValidationError):
             TtsReponseData()  # Missing responses
@@ -218,12 +226,20 @@ class TestMessagebusModels(TestCase):
 
         # Test valid message
         message_id = "test_mid"
-        response = TtsResponse(sentence="Hello world", translated=False, phonemes="")
-        data = TtsReponseData(responses={"en-us": {"female": response}})
+        response = TtsResponse(
+            sentence="Hello world", 
+            translated=False, 
+            phonemes="HH EH L OW",
+            genders=["female", "male"],
+            audio={"female": "base64audio1", "male": "base64audio2"}
+        )
+        data = TtsReponseData(responses={"en-us": response})
         valid_message = NeonTtsResponse(data=data, context={})
         self.assertIsInstance(valid_message, NeonTtsResponse)
         self.assertIsInstance(valid_message, BaseMessage)
-        self.assertEqual(valid_message.data.responses["en-us"]["female"].sentence, "Hello world")
+        self.assertEqual(valid_message.data.responses["en-us"].sentence, "Hello world")
+        self.assertEqual(valid_message.data.responses["en-us"].genders, ["female", "male"])
+        self.assertEqual(valid_message.data.responses["en-us"].audio["female"], "base64audio1")
         self.assertEqual(valid_message.msg_type, "neon.get_tts.response")
 
         # Test alternate msg_type

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -383,3 +383,281 @@ class TestMessagebusModels(TestCase):
         # Test missing required fields
         with self.assertRaises(ValidationError):
             NeonLanguagesResponse(context={})  # Missing data
+
+    def test_tts_speaker(self):
+        from neon_data_models.models.api.messagebus import TtsSpeaker
+        
+        # Test valid data
+        valid_data = {"name": "Neon", "language": "en-us", "gender": "female", "voice": "cmu-slt"}
+        speaker = TtsSpeaker(**valid_data)
+        self.assertIsInstance(speaker, TtsSpeaker)
+        self.assertEqual(speaker.name, "Neon")
+        self.assertEqual(speaker.language, "en-us")
+        self.assertEqual(speaker.gender, "female")
+        self.assertEqual(speaker.voice, "cmu-slt")
+        
+        # Test default values
+        minimal_data = {"name": "Test"}
+        speaker = TtsSpeaker(**minimal_data)
+        self.assertEqual(speaker.language, "en-us")
+        self.assertEqual(speaker.gender, "female")
+        self.assertIsNone(speaker.voice)
+        
+        # Test deprecated speaker field
+        deprecated_data = {"speaker": "Deprecated"}
+        speaker = TtsSpeaker(**deprecated_data)
+        self.assertEqual(speaker.name, "Deprecated")
+        self.assertEqual(speaker.speaker, "Deprecated")
+        
+        # Test mixed name and speaker fields (name should take precedence)
+        mixed_data = {"name": "Primary", "speaker": "Secondary"}
+        speaker = TtsSpeaker(**mixed_data)
+        self.assertEqual(speaker.name, "Primary")
+        self.assertEqual(speaker.speaker, "Secondary")
+        
+        # Test invalid gender
+        with self.assertRaises(ValidationError):
+            TtsSpeaker(name="Test", gender="invalid_gender")
+    
+    def test_get_tts_data_validation_edge_cases(self):
+        from neon_data_models.models.api.messagebus import GetTtsData
+        
+        # Test empty text
+        empty_text = {"text": ""}
+        tts_data = GetTtsData(**empty_text)
+        self.assertEqual(tts_data.text, "")
+        
+        # Test with both text and utterance (text should take precedence)
+        dual_fields = {"text": "Primary text", "utterance": "Secondary text"}
+        tts_data = GetTtsData(**dual_fields)
+        self.assertEqual(tts_data.text, "Primary text")
+        
+        # Test with custom language
+        custom_lang = {"text": "Hello", "lang": "fr-fr"}
+        tts_data = GetTtsData(**custom_lang)
+        self.assertEqual(tts_data.lang, "fr-fr")
+        
+        # Test with invalid language format (should accept but not validate format)
+        invalid_lang = {"text": "Hello", "lang": "invalid_lang"}
+        tts_data = GetTtsData(**invalid_lang)
+        self.assertEqual(tts_data.lang, "invalid_lang")
+    
+    def test_get_stt_data_validation_edge_cases(self):
+        from neon_data_models.models.api.messagebus import GetSttData
+        
+        # Test empty audio data
+        empty_audio = {"audio_data": ""}
+        stt_data = GetSttData(**empty_audio)
+        self.assertEqual(stt_data.audio_data, "")
+        
+        # Test with both audio_data and message_body (audio_data should take precedence)
+        dual_fields = {"audio_data": "Primary audio", "message_body": "Secondary audio"}
+        stt_data = GetSttData(**dual_fields)
+        self.assertEqual(stt_data.audio_data, "Primary audio")
+        
+        # Test with custom language
+        custom_lang = {"audio_data": "data", "lang": "de-de"}
+        stt_data = GetSttData(**custom_lang)
+        self.assertEqual(stt_data.lang, "de-de")
+    
+    def test_tts_response_edge_cases(self):
+        from neon_data_models.models.api.messagebus import TtsResponse
+        
+        # Test with minimum valid data
+        min_valid_data = {
+            "sentence": "Test",
+            "translated": True,
+            "genders": ["female"],
+            "audio": {"female": "audio_data"}
+        }
+        response = TtsResponse(**min_valid_data)
+        self.assertEqual(response.sentence, "Test")
+        self.assertTrue(response.translated)
+        self.assertEqual(response.genders, ["female"])
+        self.assertEqual(response.audio["female"], "audio_data")
+        
+        # Test with invalid gender in genders field
+        with self.assertRaises(ValidationError):
+            TtsResponse(
+                sentence="Test",
+                translated=False,
+                genders=["invalid_gender"],
+                audio={"female": "audio_data"}
+            )
+        
+        # Test with mismatch between genders and audio keys
+        with self.assertRaises(ValidationError):
+            TtsResponse(
+                sentence="Test",
+                translated=False,
+                genders=["male"],
+                audio={"female": "audio_data"}
+            )
+    
+    def test_tts_response_multi_language(self):
+        from neon_data_models.models.api.messagebus import TtsReponseData, TtsResponse, TtsSpeaker
+        
+        # Create multiple language responses
+        en_response = TtsResponse(
+            sentence="Hello world",
+            translated=False,
+            genders=["female", "male"],
+            audio={"female": "en_audio_female", "male": "en_audio_male"}
+        )
+        
+        es_response = TtsResponse(
+            sentence="Hola mundo",
+            translated=True,
+            genders=["female"],
+            audio={"female": "es_audio_female"}
+        )
+        
+        fr_response = TtsResponse(
+            sentence="Bonjour le monde",
+            translated=True,
+            genders=["male"],
+            audio={"male": "fr_audio_male"}
+        )
+        
+        # Test with multiple language responses
+        multi_lang_data = {
+            "responses": {
+                "en-us": en_response,
+                "es-es": es_response,
+                "fr-fr": fr_response
+            },
+            "speaker": {
+                "name": "MultiLang",
+                "language": "en-us",
+                "gender": "female"
+            }
+        }
+        
+        tts_response_data = TtsReponseData(**multi_lang_data)
+        self.assertEqual(len(tts_response_data.responses), 3)
+        self.assertEqual(tts_response_data.responses["en-us"].sentence, "Hello world")
+        self.assertEqual(tts_response_data.responses["es-es"].sentence, "Hola mundo")
+        self.assertEqual(tts_response_data.responses["fr-fr"].sentence, "Bonjour le monde")
+        self.assertEqual(tts_response_data.speaker.name, "MultiLang")
+        
+        # Verify each language's specific properties
+        self.assertFalse(tts_response_data.responses["en-us"].translated)
+        self.assertTrue(tts_response_data.responses["es-es"].translated)
+        self.assertEqual(tts_response_data.responses["en-us"].genders, ["female", "male"])
+        self.assertEqual(tts_response_data.responses["es-es"].genders, ["female"])
+        self.assertEqual(tts_response_data.responses["fr-fr"].genders, ["male"])
+    
+    def test_get_response_data_validation_edge_cases(self):
+        from neon_data_models.models.api.messagebus import GetResponseData
+        
+        # Test with a single string in messageText
+        text_string = {"messageText": "Single message"}
+        response_data = GetResponseData(**text_string)
+        self.assertEqual(response_data.utterances, ["Single message"])
+        
+        # Test with both utterances and messageText (utterances should take precedence)
+        dual_fields = {
+            "utterances": ["Primary utterance"],
+            "messageText": "Secondary utterance"
+        }
+        response_data = GetResponseData(**dual_fields)
+        self.assertEqual(response_data.utterances, ["Primary utterance"])
+        
+        # Test with multiple utterances
+        multi_utterance = {
+            "utterances": ["First utterance", "Second utterance", "Third utterance"]
+        }
+        response_data = GetResponseData(**multi_utterance)
+        self.assertEqual(len(response_data.utterances), 3)
+        self.assertEqual(response_data.utterances[1], "Second utterance")
+        
+        # Test with Unicode characters
+        unicode_text = {"utterances": ["こんにちは", "你好", "مرحبا"]}
+        response_data = GetResponseData(**unicode_text)
+        self.assertEqual(response_data.utterances[0], "こんにちは")
+    
+    def test_serialization_deserialization(self):
+        from neon_data_models.models.api.messagebus import (
+            GetTtsData, NeonGetTts, TtsResponse, TtsReponseData, NeonTtsResponse
+        )
+        import json
+        
+        # Test serialization and deserialization of GetTtsData
+        tts_data = GetTtsData(text="Serialize me", lang="en-us")
+        serialized = json.loads(tts_data.model_dump_json())
+        self.assertEqual(serialized["text"], "Serialize me")
+        self.assertEqual(serialized["lang"], "en-us")
+        
+        deserialized = GetTtsData.model_validate(serialized)
+        self.assertEqual(deserialized.text, "Serialize me")
+        self.assertEqual(deserialized.lang, "en-us")
+        
+        # Test serialization and deserialization of complete message
+        response = TtsResponse(
+            sentence="Test response",
+            translated=False,
+            phonemes="T EH S T",
+            genders=["female"],
+            audio={"female": "test_audio_data"}
+        )
+        
+        response_data = TtsReponseData(responses={"en-us": response})
+        message = NeonTtsResponse(data=response_data, context={"source": "test"})
+        
+        serialized_message = json.loads(message.model_dump_json())
+        self.assertEqual(serialized_message["msg_type"], "neon.get_tts.response")
+        self.assertEqual(serialized_message["data"]["responses"]["en-us"]["sentence"], "Test response")
+        
+        deserialized_message = NeonTtsResponse.model_validate(serialized_message)
+        self.assertEqual(deserialized_message.msg_type, "neon.get_tts.response")
+        self.assertEqual(deserialized_message.data.responses["en-us"].sentence, "Test response")
+        self.assertEqual(deserialized_message.data.responses["en-us"].audio["female"], "test_audio_data")
+    
+    def test_stt_response_data_edge_cases(self):
+        from neon_data_models.models.api.messagebus import SttReponseData
+        
+        # Test with multiple transcripts
+        multi_transcript = {
+            "transcripts": ["First guess", "Second guess", "Third guess"],
+            "parser_data": {"confidence": 0.8, "source": "test_engine"}
+        }
+        stt_response = SttReponseData(**multi_transcript)
+        self.assertEqual(len(stt_response.transcripts), 3)
+        self.assertEqual(stt_response.parser_data["confidence"], 0.8)
+        
+        # Test with complex parser data
+        complex_parser_data = {
+            "transcripts": ["Hello"],
+            "parser_data": {
+                "confidence": 0.95,
+                "engine": "test_engine",
+                "metadata": {
+                    "duration": 2.5,
+                    "sample_rate": 16000,
+                    "format": "wav",
+                    "channels": 1
+                },
+                "alternatives": [
+                    {"text": "Hello", "confidence": 0.95},
+                    {"text": "Hell no", "confidence": 0.05}
+                ]
+            }
+        }
+        stt_response = SttReponseData(**complex_parser_data)
+        self.assertEqual(stt_response.parser_data["metadata"]["sample_rate"], 16000)
+        self.assertEqual(stt_response.parser_data["alternatives"][0]["confidence"], 0.95)
+        
+        # Test with empty transcripts list (should fail)
+        with self.assertRaises(ValidationError):
+            SttReponseData(
+                transcripts=[],
+                parser_data={"confidence": 0.9}
+            )
+        
+        # Test with empty parser data (should succeed as {}is valid)
+        valid_empty_parser = {
+            "transcripts": ["Hello"],
+            "parser_data": {}
+        }
+        stt_response = SttReponseData(**valid_empty_parser)
+        self.assertEqual(len(stt_response.parser_data), 0)

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -1,0 +1,236 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2024 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from unittest import TestCase
+from pydantic import ValidationError
+
+
+class TestMessagebusModels(TestCase):
+    def test_get_tts_data(self):
+        from neon_data_models.models.api.messagebus import GetTtsData
+
+        # Test valid data
+        valid_data = {"text": "Hello world", "lang": "en-us"}
+        tts_data = GetTtsData(**valid_data)
+        self.assertIsInstance(tts_data, GetTtsData)
+        self.assertEqual(tts_data.text, "Hello world")
+        self.assertEqual(tts_data.lang, "en-us")
+
+        # Test with utterance instead of text (backward compatibility)
+        compat_data = {"utterance": "Hello world"}
+        tts_data = GetTtsData(**compat_data)
+        self.assertEqual(tts_data.text, "Hello world")
+        self.assertEqual(tts_data.lang, "en-us")  # Default value
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            GetTtsData()
+
+    def test_tts_response_data(self):
+        from neon_data_models.models.api.messagebus import TtsResponse, TtsReponseData
+
+        # Test valid response data
+        valid_response = {
+            "sentence": "Hello world",
+            "translated": False,
+            "phonemes": "HH AH L OW W ER L D"
+        }
+        tts_response = TtsResponse(**valid_response)
+        self.assertIsInstance(tts_response, TtsResponse)
+        self.assertEqual(tts_response.sentence, "Hello world")
+        self.assertEqual(tts_response.translated, False)
+        self.assertEqual(tts_response.phonemes, "HH AH L OW W ER L D")
+
+        # Test valid responses data
+        valid_responses_data = {
+            "responses": {
+                "en-us": {
+                    "female": valid_response
+                }
+            }
+        }
+        tts_responses = TtsReponseData(**valid_responses_data)
+        self.assertIsInstance(tts_responses, TtsReponseData)
+        self.assertEqual(tts_responses.responses["en-us"]["female"].sentence, "Hello world")
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            TtsResponse(sentence="Hello", phonemes="HH AH L OW")  # Missing translated
+        
+        with self.assertRaises(ValidationError):
+            TtsReponseData()  # Missing responses
+
+    def test_get_stt_data(self):
+        from neon_data_models.models.api.messagebus import GetSttData
+
+        # Test valid data
+        valid_data = {"audio_data": "base64encodedstring", "lang": "en-us"}
+        stt_data = GetSttData(**valid_data)
+        self.assertIsInstance(stt_data, GetSttData)
+        self.assertEqual(stt_data.audio_data, "base64encodedstring")
+        self.assertEqual(stt_data.lang, "en-us")
+
+        # Test with message_body instead of audio_data (backward compatibility)
+        compat_data = {"message_body": "base64encodedstring"}
+        stt_data = GetSttData(**compat_data)
+        self.assertEqual(stt_data.audio_data, "base64encodedstring")
+        self.assertEqual(stt_data.lang, "en-us")  # Default value
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            GetSttData()
+
+    def test_stt_response_data(self):
+        from neon_data_models.models.api.messagebus import SttReponseData
+
+        # Test valid data
+        valid_data = {
+            "transcripts": ["Hello world", "Hello word"],
+            "parser_data": {"confidence": 0.95}
+        }
+        stt_response_data = SttReponseData(**valid_data)
+        self.assertIsInstance(stt_response_data, SttReponseData)
+        self.assertEqual(stt_response_data.transcripts[0], "Hello world")
+        self.assertEqual(stt_response_data.parser_data["confidence"], 0.95)
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            SttReponseData(transcripts=["Hello world"])  # Missing parser_data
+        
+        with self.assertRaises(ValidationError):
+            SttReponseData(parser_data={"confidence": 0.95})  # Missing transcripts
+
+    def test_get_response_data(self):
+        from neon_data_models.models.api.messagebus import GetResponseData
+
+        # Test valid data
+        valid_data = {"utterances": ["How are you?"], "lang": "en-us"}
+        response_data = GetResponseData(**valid_data)
+        self.assertIsInstance(response_data, GetResponseData)
+        self.assertEqual(response_data.utterances, ["How are you?"])
+        self.assertEqual(response_data.lang, "en-us")
+
+        # Test with messageText instead of utterances (backward compatibility)
+        compat_data = {"messageText": "How are you?"}
+        response_data = GetResponseData(**compat_data)
+        self.assertEqual(response_data.utterances, ["How are you?"])
+        self.assertEqual(response_data.lang, "en-us")  # Default value
+
+        # Test with empty utterances
+        empty_data = {"utterances": []}
+        response_data = GetResponseData(**empty_data)
+        self.assertEqual(response_data.utterances, [])
+
+    def test_neon_get_tts(self):
+        from neon_data_models.models.api.messagebus import NeonGetTts, GetTtsData
+        from neon_data_models.models.base.messagebus import BaseMessage
+
+        # Test valid message
+        message_id = "test_mid"
+        data = GetTtsData(text="Hello world")
+        valid_message = NeonGetTts(data=data, context={})
+        self.assertIsInstance(valid_message, NeonGetTts)
+        self.assertIsInstance(valid_message, BaseMessage)
+        self.assertEqual(valid_message.data.text, "Hello world")
+        self.assertEqual(valid_message.msg_type, "neon.get_tts")
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            NeonGetTts(message_id=message_id, context={})  # Missing data
+
+    def test_neon_get_stt(self):
+        from neon_data_models.models.api.messagebus import NeonGetStt, GetSttData
+        from neon_data_models.models.base.messagebus import BaseMessage
+
+        # Test valid message
+        message_id = "test_mid"
+        data = GetSttData(audio_data="base64encodedstring")
+        valid_message = NeonGetStt(data=data, context={})
+        self.assertIsInstance(valid_message, NeonGetStt)
+        self.assertIsInstance(valid_message, BaseMessage)
+        self.assertEqual(valid_message.data.audio_data, "base64encodedstring")
+        self.assertEqual(valid_message.msg_type, "neon.get_stt")
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            NeonGetStt(message_id=message_id, context={})  # Missing data
+
+    def test_neon_get_response(self):
+        from neon_data_models.models.api.messagebus import NeonGetResponse, GetResponseData
+        from neon_data_models.models.base.messagebus import BaseMessage
+
+        # Test valid message
+        message_id = "test_mid"
+        data = GetResponseData(utterances=["How are you?"])
+        valid_message = NeonGetResponse(data=data, context={})
+        self.assertIsInstance(valid_message, NeonGetResponse)
+        self.assertIsInstance(valid_message, BaseMessage)
+        self.assertEqual(valid_message.data.utterances, ["How are you?"])
+        self.assertEqual(valid_message.msg_type, "recognizer_loop:utterance")
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            NeonGetResponse(message_id=message_id, context={})  # Missing data
+
+    def test_neon_stt_response(self):
+        from neon_data_models.models.api.messagebus import NeonSttResponse, SttReponseData
+        from neon_data_models.models.base.messagebus import BaseMessage
+
+        # Test valid message
+        message_id = "test_mid"
+        data = SttReponseData(transcripts=["Hello world"], parser_data={"confidence": 0.95})
+        valid_message = NeonSttResponse(data=data, context={})
+        self.assertIsInstance(valid_message, NeonSttResponse)
+        self.assertIsInstance(valid_message, BaseMessage)
+        self.assertEqual(valid_message.data.transcripts[0], "Hello world")
+        self.assertEqual(valid_message.msg_type, "neon.get_stt.response")
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            NeonSttResponse(message_id=message_id, context={})  # Missing data
+
+    def test_neon_tts_response(self):
+        from neon_data_models.models.api.messagebus import NeonTtsResponse, TtsReponseData, TtsResponse
+        from neon_data_models.models.base.messagebus import BaseMessage
+
+        # Test valid message
+        message_id = "test_mid"
+        response = TtsResponse(sentence="Hello world", translated=False, phonemes="")
+        data = TtsReponseData(responses={"en-us": {"female": response}})
+        valid_message = NeonTtsResponse(data=data, context={})
+        self.assertIsInstance(valid_message, NeonTtsResponse)
+        self.assertIsInstance(valid_message, BaseMessage)
+        self.assertEqual(valid_message.data.responses["en-us"]["female"].sentence, "Hello world")
+        self.assertEqual(valid_message.msg_type, "neon.get_tts.response")
+
+        # Test alternate msg_type
+        alt_message = NeonTtsResponse(data=data, message_id=message_id, context={}, 
+                                    msg_type="klat.response")
+        self.assertEqual(alt_message.msg_type, "klat.response")
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            NeonTtsResponse(message_id=message_id, context={})  # Missing data

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -81,7 +81,7 @@ class TestMessagebusModels(TestCase):
         self.assertIsInstance(tts_response_no_phonemes, TtsResponse)
         self.assertEqual(tts_response_no_phonemes.sentence, "Hello world")
         self.assertEqual(tts_response_no_phonemes.translated, False)
-        self.assertIsInstance(tts_response_no_phonemes.phonemes, str)
+        self.assertIsNone(tts_response_no_phonemes.phonemes)
         self.assertEqual(tts_response_no_phonemes.genders, ["female", "male"])
         self.assertEqual(tts_response_no_phonemes.audio["female"], "base64audio1")
         self.assertEqual(tts_response_no_phonemes.audio["male"], "base64audio2")

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -179,21 +179,21 @@ class TestMessagebusModels(TestCase):
             NeonGetStt(message_id=message_id, context={})  # Missing data
 
     def test_neon_get_response(self):
-        from neon_data_models.models.api.messagebus import NeonGetResponse, GetResponseData
+        from neon_data_models.models.api.messagebus import NeonTextInput, GetResponseData
         from neon_data_models.models.base.messagebus import BaseMessage
 
         # Test valid message
         message_id = "test_mid"
         data = GetResponseData(utterances=["How are you?"])
-        valid_message = NeonGetResponse(data=data, context={})
-        self.assertIsInstance(valid_message, NeonGetResponse)
+        valid_message = NeonTextInput(data=data, context={})
+        self.assertIsInstance(valid_message, NeonTextInput)
         self.assertIsInstance(valid_message, BaseMessage)
         self.assertEqual(valid_message.data.utterances, ["How are you?"])
         self.assertEqual(valid_message.msg_type, "recognizer_loop:utterance")
 
         # Test missing required fields
         with self.assertRaises(ValidationError):
-            NeonGetResponse(message_id=message_id, context={})  # Missing data
+            NeonTextInput(message_id=message_id, context={})  # Missing data
 
     def test_neon_stt_response(self):
         from neon_data_models.models.api.messagebus import NeonSttResponse, SttReponseData
@@ -234,3 +234,26 @@ class TestMessagebusModels(TestCase):
         # Test missing required fields
         with self.assertRaises(ValidationError):
             NeonTtsResponse(message_id=message_id, context={})  # Missing data
+
+    def test_neon_audio_input(self):
+        from neon_data_models.models.api.messagebus import NeonAudioInput, GetSttData
+        from neon_data_models.models.base.messagebus import BaseMessage
+
+        # Test valid message
+        message_id = "test_mid"
+        data = GetSttData(audio_data="base64encodedstring")
+        valid_message = NeonAudioInput(data=data, context={})
+        self.assertIsInstance(valid_message, NeonAudioInput)
+        self.assertIsInstance(valid_message, BaseMessage)
+        self.assertEqual(valid_message.data.audio_data, "base64encodedstring")
+        self.assertEqual(valid_message.data.lang, "en-us")  # Default value
+        self.assertEqual(valid_message.msg_type, "neon.audio_input")
+
+        # Test with message_body instead of audio_data (backward compatibility)
+        compat_data = GetSttData(message_body="different_base64string")
+        compat_message = NeonAudioInput(data=compat_data, context={})
+        self.assertEqual(compat_message.data.audio_data, "different_base64string")
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            NeonAudioInput(message_id=message_id, context={})  # Missing data

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -70,6 +70,22 @@ class TestMessagebusModels(TestCase):
         self.assertEqual(tts_response.audio["female"], "base64audio1")
         self.assertEqual(tts_response.audio["male"], "base64audio2")
 
+        # Test valid response data without phonemes
+        valid_response_no_phonemes = {
+            "sentence": "Hello world",
+            "translated": False,
+            "genders": ["female", "male"],
+            "audio": {"female": "base64audio1", "male": "base64audio2"}
+        }
+        tts_response_no_phonemes = TtsResponse(**valid_response_no_phonemes)
+        self.assertIsInstance(tts_response_no_phonemes, TtsResponse)
+        self.assertEqual(tts_response_no_phonemes.sentence, "Hello world")
+        self.assertEqual(tts_response_no_phonemes.translated, False)
+        self.assertIsInstance(tts_response_no_phonemes.phonemes, str)
+        self.assertEqual(tts_response_no_phonemes.genders, ["female", "male"])
+        self.assertEqual(tts_response_no_phonemes.audio["female"], "base64audio1")
+        self.assertEqual(tts_response_no_phonemes.audio["male"], "base64audio2")
+
         # Test valid responses data
         valid_responses_data = {
             "responses": {

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -597,3 +597,109 @@ class TestNeonMQ(TestCase):
         direct_api_message = NeonApiMessage(**direct_message)
         self.assertEqual(direct_api_message.message_id, "direct_mid")
 
+    def test_neon_mq_audio_input(self):
+        from neon_data_models.models.api.mq.neon import NeonMqAudioInput, GetSttData
+        from neon_data_models.models.api.messagebus import NeonAudioInput
+        from neon_data_models.models.base.contexts import MQContext
+
+        # Test valid request
+        message_id = "test_mid"
+        data = GetSttData(audio_data="base64encodedstring")
+        valid_request = NeonMqAudioInput(data=data, message_id=message_id, context={})
+        self.assertIsInstance(valid_request, NeonMqAudioInput)
+        self.assertIsInstance(valid_request, NeonAudioInput)
+        self.assertIsInstance(valid_request, MQContext)
+        self.assertEqual(valid_request.data.audio_data, "base64encodedstring")
+        self.assertEqual(valid_request.message_id, message_id)
+        self.assertEqual(valid_request.msg_type, "neon.audio_input")
+
+        # Test missing MQ required data
+        with self.assertRaises(ValidationError):
+            NeonMqAudioInput(data=data)
+
+        # Test missing data required
+        with self.assertRaises(ValidationError):
+            NeonMqAudioInput(message_id=message_id)
+
+    def test_neon_mq_get_languages(self):
+        from neon_data_models.models.api.mq.neon import NeonMqGetLanguages
+        from neon_data_models.models.api.messagebus import NeonGetLanguages
+        from neon_data_models.models.base.contexts import MQContext
+
+        # Test valid request
+        message_id = "test_mid"
+        valid_request = NeonMqGetLanguages(message_id=message_id, data={},
+                                            context={})
+        self.assertIsInstance(valid_request, NeonMqGetLanguages)
+        self.assertIsInstance(valid_request, NeonGetLanguages)
+        self.assertIsInstance(valid_request, MQContext)
+        self.assertEqual(valid_request.message_id, message_id)
+        self.assertEqual(valid_request.msg_type, "neon.languages.get")
+
+        # Test missing MQ required data
+        with self.assertRaises(ValidationError):
+            NeonMqGetLanguages()
+
+    def test_neon_mq_languages_response(self):
+        from neon_data_models.models.api.mq.neon import NeonMqLanguagesResponse
+        from neon_data_models.models.api.messagebus import NeonLanguagesResponse, NeonLanguagesData
+        from neon_data_models.models.base.contexts import MQContext
+
+        # Test valid response
+        message_id = "test_mid"
+        data = NeonLanguagesData(
+            stt=["en-us", "es-es"],
+            tts=["en-us", "fr-fr"],
+            skills=["en-us"]
+        )
+        valid_response = NeonMqLanguagesResponse(data=data, message_id=message_id, context={})
+        self.assertIsInstance(valid_response, NeonMqLanguagesResponse)
+        self.assertIsInstance(valid_response, NeonLanguagesResponse)
+        self.assertIsInstance(valid_response, MQContext)
+        self.assertEqual(valid_response.message_id, message_id)
+        self.assertEqual(valid_response.msg_type, "neon.languages.get.response")
+        self.assertEqual(valid_response.data.stt, ["en-us", "es-es"])
+        self.assertEqual(valid_response.data.tts, ["en-us", "fr-fr"])
+        self.assertEqual(valid_response.data.skills, ["en-us"])
+
+        # Test missing MQ required data
+        with self.assertRaises(ValidationError):
+            NeonMqLanguagesResponse(data=data)
+
+        # Test missing data required
+        with self.assertRaises(ValidationError):
+            NeonMqLanguagesResponse(message_id=message_id)
+
+    def test_neon_api_message_languages(self):
+        from neon_data_models.models.api.mq.neon import NeonApiMessage
+        from neon_data_models.models.api.mq.neon import NeonMqGetLanguages, NeonMqLanguagesResponse
+        from neon_data_models.models.api.messagebus import NeonLanguagesData
+
+        # Test GetLanguages message
+        languages_get_message = NeonApiMessage(
+            msg_type="neon.languages.get",
+            data={},
+            context={},
+            message_id="test_mid"
+        )
+        self.assertIsInstance(languages_get_message, NeonMqGetLanguages)
+        self.assertEqual(languages_get_message.message_id, "test_mid")
+        self.assertEqual(languages_get_message.msg_type, "neon.languages.get")
+
+        # Test LanguagesResponse message
+        languages_data = NeonLanguagesData(
+            stt=["en-us", "es-es"],
+            tts=["en-us", "fr-fr"],
+            skills=["en-us"]
+        )
+        languages_response = NeonApiMessage(
+            msg_type="neon.languages.get.response",
+            data=languages_data,
+            context={},
+            message_id="test_mid"
+        )
+        self.assertIsInstance(languages_response, NeonMqLanguagesResponse)
+        self.assertEqual(languages_response.data.stt, ["en-us", "es-es"])
+        self.assertEqual(languages_response.data.tts, ["en-us", "fr-fr"])
+        self.assertEqual(languages_response.data.skills, ["en-us"])
+

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -383,26 +383,26 @@ class TestNeonMQ(TestCase):
             NeonMqGetStt(message_id=message_id)
 
     def test_neon_mq_get_response(self):
-        from neon_data_models.models.api.mq.neon import NeonMqGetResponse, GetResponseData
+        from neon_data_models.models.api.mq.neon import NeonMqTextInput, GetResponseData
         from neon_data_models.models.base.contexts import MQContext
 
         # Test valid request
         message_id = "test_mid"
         data = GetResponseData(utterances=["How are you?"])
-        valid_request = NeonMqGetResponse(data=data, message_id=message_id,
+        valid_request = NeonMqTextInput(data=data, message_id=message_id,
                                           context={})
-        self.assertIsInstance(valid_request, NeonMqGetResponse)
+        self.assertIsInstance(valid_request, NeonMqTextInput)
         self.assertIsInstance(valid_request, MQContext)
         self.assertEqual(valid_request.data.utterances, ["How are you?"])
         self.assertEqual(valid_request.message_id, message_id)
 
         # Test missing MQ required data
         with self.assertRaises(ValidationError):
-            NeonMqGetResponse(data=data)
+            NeonMqTextInput(data=data)
 
         # Test missing data required
         with self.assertRaises(ValidationError):
-            NeonMqGetResponse(message_id=message_id)
+            NeonMqTextInput(message_id=message_id)
 
     def test_neon_mq_stt_response(self):
         from neon_data_models.models.api.mq.neon import NeonMqSttResponse
@@ -446,7 +446,7 @@ class TestNeonMQ(TestCase):
 
     def test_neon_api_message(self):
         from neon_data_models.models.api.mq.neon import NeonApiMessage, GetTtsData, GetSttData, GetResponseData
-        from neon_data_models.models.api.mq.neon import NeonMqGetTts, NeonMqGetStt, NeonMqGetResponse
+        from neon_data_models.models.api.mq.neon import NeonMqGetTts, NeonMqGetStt, NeonMqTextInput
         from neon_data_models.models.api.mq.neon import NeonMqSttResponse, NeonMqTtsResponse
 
         # Test TTS message
@@ -474,7 +474,7 @@ class TestNeonMQ(TestCase):
             context={},
             message_id="test_mid"
         )
-        self.assertIsInstance(response_message, NeonMqGetResponse)
+        self.assertIsInstance(response_message, NeonMqTextInput)
 
         # Test STT response
         stt_response = NeonApiMessage(
@@ -489,9 +489,12 @@ class TestNeonMQ(TestCase):
         # Test TTS response
         tts_response = NeonApiMessage(
             msg_type="neon.get_tts.response",
-            data={"responses": {"en-us": {"female": {"sentence": "test",
-                                                     "translated": False,
-                                                     "phonemes": ""}}}},
+            data={"responses": {"en-us": {"sentence": "test",
+                                          "translated": False,
+                                          "phonemes": "",
+                                          "genders": ["female"],
+                                          "audio": {
+                                          "female": "fake_b64_audio"}}}},
             context={},
             message_id="test_mid"
         )
@@ -539,7 +542,7 @@ class TestNeonMQ(TestCase):
             "message_id": "test_mid"
         }
         recognizer_req = NeonApiMessage.from_sio_message(sio_recognizer)
-        self.assertIsInstance(recognizer_req, NeonMqGetResponse)
+        self.assertIsInstance(recognizer_req, NeonMqTextInput)
         self.assertEqual(recognizer_req.data.utterances, ["How are you?"])
 
         # Test invalid requested_skill

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -28,7 +28,7 @@ from unittest import TestCase
 from pydantic import ValidationError
 
 
-class TestMQ(TestCase):
+class TestUsersMQ(TestCase):
     def test_create_user_db_request(self):
         from neon_data_models.models.api.mq.users import UserDbRequest, CreateUserRequest
 
@@ -126,6 +126,8 @@ class TestMQ(TestCase):
             UserDbRequest(operation="delete", username="test_user",
                           message_id="test0")
 
+
+class TestLLMMQ(TestCase):
     def test_mq_llm_propose_request(self):
         from neon_data_models.models.api.mq.llm import LLMProposeRequest
         from neon_data_models.models.api.llm import LLMRequest
@@ -272,5 +274,275 @@ class TestMQ(TestCase):
         # Invalid response data
         with self.assertRaises(ValidationError):
             LLMVoteResponse(sorted_answer_indexes=[2, 0, 1, "invalid"],
-                            message_id=""),
+                            message_id="")
+
+
+class TestNeonMQ(TestCase):
+    def test_get_tts_data(self):
+        from neon_data_models.models.api.mq.neon import GetTtsData
+
+        # Test valid data
+        valid_data = {"text": "Hello world", "lang": "en-us"}
+        tts_data = GetTtsData(**valid_data)
+        self.assertIsInstance(tts_data, GetTtsData)
+        self.assertEqual(tts_data.text, "Hello world")
+        self.assertEqual(tts_data.lang, "en-us")
+
+        # Test with utterance instead of text (backward compatibility)
+        compat_data = {"utterance": "Hello world"}
+        tts_data = GetTtsData(**compat_data)
+        self.assertEqual(tts_data.text, "Hello world")
+        self.assertEqual(tts_data.lang, "en-us")  # Default value
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            GetTtsData()
+
+    def test_get_stt_data(self):
+        from neon_data_models.models.api.mq.neon import GetSttData
+
+        # Test valid data
+        valid_data = {"audio_data": "base64encodedstring", "lang": "en-us"}
+        stt_data = GetSttData(**valid_data)
+        self.assertIsInstance(stt_data, GetSttData)
+        self.assertEqual(stt_data.audio_data, "base64encodedstring")
+        self.assertEqual(stt_data.lang, "en-us")
+
+        # Test with message_body instead of audio_data (backward compatibility)
+        compat_data = {"message_body": "base64encodedstring"}
+        stt_data = GetSttData(**compat_data)
+        self.assertEqual(stt_data.audio_data, "base64encodedstring")
+        self.assertEqual(stt_data.lang, "en-us")  # Default value
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            GetSttData()
+
+    def test_get_response_data(self):
+        from neon_data_models.models.api.mq.neon import GetResponseData
+
+        # Test valid data
+        valid_data = {"utterances": ["How are you?"], "lang": "en-us"}
+        response_data = GetResponseData(**valid_data)
+        self.assertIsInstance(response_data, GetResponseData)
+        self.assertEqual(response_data.utterances, ["How are you?"])
+        self.assertEqual(response_data.lang, "en-us")
+
+        # Test with messageText instead of utterances (backward compatibility)
+        compat_data = {"messageText": "How are you?"}
+        response_data = GetResponseData(**compat_data)
+        self.assertEqual(response_data.utterances, ["How are you?"])
+        self.assertEqual(response_data.lang, "en-us")  # Default value
+
+        # Test with empty utterances
+        empty_data = {"utterances": []}
+        response_data = GetResponseData(**empty_data)
+        self.assertEqual(response_data.utterances, [])
+
+    def test_neon_mq_get_tts(self):
+        from neon_data_models.models.api.mq.neon import NeonMqGetTts, GetTtsData
+        from neon_data_models.models.base.contexts import MQContext
+
+        # Test valid request
+        message_id = "test_mid"
+        data = GetTtsData(text="Hello world")
+        valid_request = NeonMqGetTts(data=data, message_id=message_id, context={})
+        self.assertIsInstance(valid_request, NeonMqGetTts)
+        self.assertIsInstance(valid_request, MQContext)
+        self.assertEqual(valid_request.data.text, "Hello world")
+        self.assertEqual(valid_request.message_id, message_id)
+
+        # Test missing MQ required data
+        with self.assertRaises(ValidationError):
+            NeonMqGetTts(data=data)
+
+        # Test missing data required
+        with self.assertRaises(ValidationError):
+            NeonMqGetTts(message_id=message_id)
+
+    def test_neon_mq_get_stt(self):
+        from neon_data_models.models.api.mq.neon import NeonMqGetStt, GetSttData
+        from neon_data_models.models.base.contexts import MQContext
+
+        # Test valid request
+        message_id = "test_mid"
+        data = GetSttData(audio_data="base64encodedstring")
+        valid_request = NeonMqGetStt(data=data, message_id=message_id,
+                                     context={})
+        self.assertIsInstance(valid_request, NeonMqGetStt)
+        self.assertIsInstance(valid_request, MQContext)
+        self.assertEqual(valid_request.data.audio_data, "base64encodedstring")
+        self.assertEqual(valid_request.message_id, message_id)
+
+        # Test missing MQ required data
+        with self.assertRaises(ValidationError):
+            NeonMqGetStt(data=data)
+
+        # Test missing data required
+        with self.assertRaises(ValidationError):
+            NeonMqGetStt(message_id=message_id)
+
+    def test_neon_mq_get_response(self):
+        from neon_data_models.models.api.mq.neon import NeonMqGetResponse, GetResponseData
+        from neon_data_models.models.base.contexts import MQContext
+
+        # Test valid request
+        message_id = "test_mid"
+        data = GetResponseData(utterances=["How are you?"])
+        valid_request = NeonMqGetResponse(data=data, message_id=message_id,
+                                          context={})
+        self.assertIsInstance(valid_request, NeonMqGetResponse)
+        self.assertIsInstance(valid_request, MQContext)
+        self.assertEqual(valid_request.data.utterances, ["How are you?"])
+        self.assertEqual(valid_request.message_id, message_id)
+
+        # Test missing MQ required data
+        with self.assertRaises(ValidationError):
+            NeonMqGetResponse(data=data)
+
+        # Test missing data required
+        with self.assertRaises(ValidationError):
+            NeonMqGetResponse(message_id=message_id)
+
+    def test_neon_mq_stt_response(self):
+        from neon_data_models.models.api.mq.neon import NeonMqSttResponse
+        # TODO: This needs defined serialized messages
+        # # Test valid response
+        # valid_response = NeonMqSttResponse(
+        #     transcription="Hello world",
+        #     message_id="test_mid"
+        # )
+        # self.assertIsInstance(valid_response, NeonMqSttResponse)
+        # self.assertEqual(valid_response.transcription, "Hello world")
+        # self.assertEqual(valid_response.message_id, "test_mid")
+
+        # # Test missing MQ required data
+        # with self.assertRaises(ValidationError):
+        #     NeonMqSttResponse(transcription="Hello world")
+
+        # # Test missing transcription data
+        # with self.assertRaises(ValidationError):
+        #     NeonMqSttResponse(message_id="test_mid")
+
+    def test_neon_mq_tts_response(self):
+        from neon_data_models.models.api.mq.neon import NeonMqTtsResponse
+        # TODO: This needs defined serialized messages
+        # # Test valid response
+        # valid_response = NeonMqTtsResponse(
+        #     audio_data="base64encodedstring",
+        #     message_id="test_mid"
+        # )
+        # self.assertIsInstance(valid_response, NeonMqTtsResponse)
+        # self.assertEqual(valid_response.audio_data, "base64encodedstring")
+        # self.assertEqual(valid_response.message_id, "test_mid")
+
+        # # Test missing MQ required data
+        # with self.assertRaises(ValidationError):
+        #     NeonMqTtsResponse(audio_data="base64encodedstring")
+
+        # # Test missing audio data
+        # with self.assertRaises(ValidationError):
+        #     NeonMqTtsResponse(message_id="test_mid")
+
+    def test_neon_api_message(self):
+        from neon_data_models.models.api.mq.neon import NeonApiMessage, GetTtsData, GetSttData, GetResponseData
+        from neon_data_models.models.api.mq.neon import NeonMqGetTts, NeonMqGetStt, NeonMqGetResponse
+        from neon_data_models.models.api.mq.neon import NeonMqSttResponse, NeonMqTtsResponse
+
+        # Test TTS message
+        tts_message = NeonApiMessage(
+            msg_type="neon.get_tts",
+            data=GetTtsData(text="Hello world"),
+            context={},
+            message_id="test_mid"
+        )
+        self.assertIsInstance(tts_message, NeonMqGetTts)
+
+        # Test STT message
+        stt_message = NeonApiMessage(
+            msg_type="neon.get_stt",
+            data=GetSttData(audio_data="base64encodedstring"),
+            context={},
+            message_id="test_mid"
+        )
+        self.assertIsInstance(stt_message, NeonMqGetStt)
+
+        # Test get response message
+        response_message = NeonApiMessage(
+            msg_type="recognizer_loop:utterance",
+            data=GetResponseData(utterances=["How are you?"]),
+            context={},
+            message_id="test_mid"
+        )
+        self.assertIsInstance(response_message, NeonMqGetResponse)
+
+        # Test STT response
+        stt_response = NeonApiMessage(
+            msg_type="neon.get_stt.response",
+            data={"transcripts": ["test"],
+                  "parser_data": {}},
+            context={},
+            message_id="test_mid"
+        )
+        self.assertIsInstance(stt_response, NeonMqSttResponse)
+
+        # Test TTS response
+        tts_response = NeonApiMessage(
+            msg_type="neon.get_tts.response",
+            data={"responses": {"en-us": {"female": {"sentence": "test",
+                                                     "translated": False,
+                                                     "phonemes": ""}}}},
+            context={},
+            message_id="test_mid"
+        )
+        self.assertIsInstance(tts_response, NeonMqTtsResponse)
+
+        # Test from_sio_message for STT
+        sio_stt = {
+            "requested_skill": "stt",
+            "message_body": "base64encodedstring",
+            "client": "test_client",
+            "nick": "test_user",
+            "cid": "test_session",
+            "sid": "test_shout_id",
+            "timeCreated": 123456789,
+            "message_id": "test_mid"
+        }
+        stt_req = NeonApiMessage.from_sio_message(sio_stt)
+        self.assertIsInstance(stt_req, NeonMqGetStt)
+        self.assertEqual(stt_req.data.audio_data, "base64encodedstring")
+
+        # Test from_sio_message for TTS
+        sio_tts = {
+            "requested_skill": "tts",
+            "utterance": "Hello world",
+            "client": "test_client",
+            "nick": "test_user",
+            "cid": "test_session",
+            "sid": "test_shout_id",
+            "timeCreated": 123456789,
+            "message_id": "test_mid"
+        }
+        tts_req = NeonApiMessage.from_sio_message(sio_tts)
+        self.assertIsInstance(tts_req, NeonMqGetTts)
+        self.assertEqual(tts_req.data.text, "Hello world")
+
+        # Test from_sio_message for recognizer
+        sio_recognizer = {
+            "requested_skill": "recognizer",
+            "messageText": "How are you?",
+            "client": "test_client",
+            "nick": "test_user",
+            "cid": "test_session",
+            "sid": "test_shout_id",
+            "timeCreated": 123456789,
+            "message_id": "test_mid"
+        }
+        recognizer_req = NeonApiMessage.from_sio_message(sio_recognizer)
+        self.assertIsInstance(recognizer_req, NeonMqGetResponse)
+        self.assertEqual(recognizer_req.data.utterances, ["How are you?"])
+
+        # Test invalid requested_skill
+        with self.assertRaises(ValueError):
+            NeonApiMessage.from_sio_message({"requested_skill": "invalid"})
 

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -703,3 +703,94 @@ class TestNeonMQ(TestCase):
         self.assertEqual(languages_response.data.tts, ["en-us", "fr-fr"])
         self.assertEqual(languages_response.data.skills, ["en-us"])
 
+    def test_neon_mq_unknown_message(self):
+        from neon_data_models.models.api.mq.neon import NeonMqUnknownMessage
+        from neon_data_models.models.base.messagebus import BaseMessage
+        from neon_data_models.models.base.contexts import MQContext
+
+        # Test valid initialization
+        unknown_message = NeonMqUnknownMessage(
+            msg_type="unknown.type",
+            message_id="test_mid",
+            data={},
+            context={}
+        )
+        
+        # Test inheritance
+        self.assertIsInstance(unknown_message, NeonMqUnknownMessage)
+        self.assertIsInstance(unknown_message, BaseMessage)
+        self.assertIsInstance(unknown_message, MQContext)
+        
+        # Test properties
+        self.assertEqual(unknown_message.msg_type, "unknown.type")
+        self.assertEqual(unknown_message.message_id, "test_mid")
+        
+        # Test with missing required fields
+        with self.assertRaises(ValidationError):
+            NeonMqUnknownMessage()
+
+    def test_neon_api_message_fallback(self):
+        from neon_data_models.models.api.mq.neon import NeonApiMessage, NeonMqUnknownMessage
+        
+        # Test with unknown message type
+        unknown_message_data = {
+            "msg_type": "unknown.message.type",
+            "message_id": "test_mid",
+            "data": {"some_field": "some_value"},
+            "context": {}
+        }
+        
+        message = NeonApiMessage(**unknown_message_data)
+        
+        # Verify fallback to NeonMqUnknownMessage
+        self.assertIsInstance(message, NeonMqUnknownMessage)
+        self.assertEqual(message.msg_type, "unknown.message.type")
+        self.assertEqual(message.message_id, "test_mid")
+        
+        # Test with the specific problematic message type from the error
+        ovos_stt_message = {
+            "msg_type": "ovos.languages.stt.response",
+            "message_id": "test_mid",
+            "data": {"languages": ["en-us", "es-es"]},
+            "context": {}
+        }
+        
+        message = NeonApiMessage(**ovos_stt_message)
+        
+        # Verify it doesn't raise an exception and preserves the data
+        self.assertIsInstance(message, NeonMqUnknownMessage)
+        self.assertEqual(message.msg_type, "ovos.languages.stt.response")
+        self.assertEqual(message.message_id, "test_mid")
+        self.assertEqual(message.data, {"languages": ["en-us", "es-es"]})
+
+    def test_neon_api_message_with_nested_data(self):
+        from neon_data_models.models.api.mq.neon import NeonApiMessage, NeonMqUnknownMessage
+        
+        # Test with deeply nested data
+        complex_message = {
+            "msg_type": "complex.unknown.type",
+            "message_id": "test_mid",
+            "data": {
+                "nested": {
+                    "deeply": {
+                        "value": "test"
+                    }
+                },
+                "list_data": [1, 2, 3, {"key": "value"}]
+            },
+            "context": {
+                "client": "test_client",
+                "user": "test_user"
+            }
+        }
+        
+        message = NeonApiMessage(**complex_message)
+        
+        # Verify complex data is preserved
+        self.assertIsInstance(message, NeonMqUnknownMessage)
+        self.assertEqual(message.msg_type, "complex.unknown.type")
+        self.assertEqual(message.message_id, "test_mid")
+        self.assertEqual(message.data["nested"]["deeply"]["value"], "test")
+        self.assertEqual(message.data["list_data"][3]["key"], "value")
+        self.assertEqual(message.context.client, "test_client")
+

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -546,3 +546,51 @@ class TestNeonMQ(TestCase):
         with self.assertRaises(ValueError):
             NeonApiMessage.from_sio_message({"requested_skill": "invalid"})
 
+    def test_neon_mq_text_input(self):
+        from neon_data_models.models.api.mq.neon import NeonMqTextInput, GetResponseData
+        from neon_data_models.models.base.contexts import MQContext
+
+        # Test valid request
+        message_id = "test_mid"
+        data = GetResponseData(utterances=["How are you?"])
+        valid_request = NeonMqTextInput(data=data, message_id=message_id,
+                                       context={})
+        self.assertIsInstance(valid_request, NeonMqTextInput)
+        self.assertIsInstance(valid_request, MQContext)
+        self.assertEqual(valid_request.data.utterances, ["How are you?"])
+        self.assertEqual(valid_request.message_id, message_id)
+
+        # Test missing MQ required data
+        with self.assertRaises(ValidationError):
+            NeonMqTextInput(data=data)
+
+        # Test missing data required
+        with self.assertRaises(ValidationError):
+            NeonMqTextInput(message_id=message_id)
+
+    def test_neon_api_message_validation(self):
+        from neon_data_models.models.api.mq.neon import NeonApiMessage, GetTtsData
+
+        # Test parse_from_messagebus validator with MQ context in a nested field
+        message_with_mq = {
+            "msg_type": "neon.get_tts",
+            "data": {"text": "Hello world"},
+            "context": {"mq": {
+                "message_id": "mq_mid"
+            }}
+        }
+        
+        api_message = NeonApiMessage(**message_with_mq)
+        self.assertEqual(api_message.message_id, "mq_mid")
+        
+        # Test with direct MQ context fields
+        direct_message = {
+            "msg_type": "neon.get_tts",
+            "data": {"text": "Hello world"},
+            "context": {},
+            "message_id": "direct_mid"
+        }
+        
+        direct_api_message = NeonApiMessage(**direct_message)
+        self.assertEqual(direct_api_message.message_id, "direct_mid")
+

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/tests/models/api/test_node.py
+++ b/tests/models/api/test_node.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -356,6 +356,7 @@ class TestContexts(TestCase):
 
 class TestMessagebus(TestCase):
     def test_base_model(self):
+        from ovos_bus_client.message import Message
         from neon_data_models.models.base.messagebus import BaseMessage
         from neon_data_models.models.client import NodeData
         from neon_data_models.models.user import NeonUserConfig
@@ -376,6 +377,12 @@ class TestMessagebus(TestCase):
         # Defined keys will generate objects
         self.assertIsInstance(message.context.node_data, NodeData)
         self.assertIsInstance(message.context.user_profiles[0], NeonUserConfig)
+
+        as_messagebus = message.as_message()
+        self.assertIsInstance(as_messagebus, Message)
+        self.assertEqual(as_messagebus.msg_type, message.msg_type)
+        self.assertEqual(as_messagebus.data, message.data)
+        self.assertEqual(as_messagebus.context, message.context.model_dump())
 
         serialized = message.model_dump()
         # Extra context keys are always retained for compat.

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -464,3 +464,28 @@ class TestMessagebus(TestCase):
         # Test round-trip
         deserialized = MessageContext(**serialized)
         self.assertEqual(deserialized.destination, ["test"])
+
+        # Test session=None validation
+        none_session_context = MessageContext(session=None)
+        self.assertIsNotNone(none_session_context.session)
+        self.assertIsInstance(none_session_context.session, SessionContext)
+        
+        # Test that the default is used when None is provided
+        default_session = SessionContext()
+        self.assertEqual(none_session_context.session.model_dump(), 
+                         default_session.model_dump())
+        
+        # Test serialization with None session that gets defaulted
+        serialized = none_session_context.model_dump(exclude_none=True)
+        self.assertIn("session", serialized)
+        self.assertEqual(serialized["session"], default_session.model_dump())
+        
+        # Test round-trip serialization
+        deserialized = MessageContext(**serialized)
+        self.assertEqual(deserialized.session.model_dump(), 
+                         default_session.model_dump())
+        
+        # Test when None is passed in a nested dictionary
+        nested_none_context = MessageContext(**{"session": None})
+        self.assertIsNotNone(nested_none_context.session)
+        self.assertIsInstance(nested_none_context.session, SessionContext)

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -26,6 +26,8 @@
 
 import importlib
 import os
+import json
+
 from datetime import datetime, timedelta, timezone
 from unittest import TestCase
 from time import time
@@ -101,9 +103,6 @@ class TestContexts(TestCase):
 
     def test_timing_context(self):
         from neon_data_models.models.base.contexts import TimingContext
-        from datetime import datetime, timedelta, timezone
-
-        import json
         
         default = TimingContext()
         self.assertIsNone(default.model_dump()['handle_utterance'])
@@ -397,7 +396,7 @@ class TestMessagebus(TestCase):
         self.assertIsInstance(message.context.node_data, NodeData)
         self.assertIsInstance(message.context.user_profiles[0], NeonUserConfig)
 
-        as_messagebus = message.as_message()
+        as_messagebus = message.as_messagebus_message()
         self.assertIsInstance(as_messagebus, Message)
         self.assertEqual(as_messagebus.msg_type, message.msg_type)
         self.assertEqual(as_messagebus.data, message.data)

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -26,7 +26,7 @@
 
 import importlib
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import TestCase
 from time import time
 from pydantic import ValidationError
@@ -128,7 +128,7 @@ class TestContexts(TestCase):
         self.assertEqual(timing, TimingContext(**serialized))
 
         # Create a TimingContext with sample data
-        now = datetime.now()
+        now = datetime.now(tz=timezone.utc)
         one_second = timedelta(seconds=1)
         
         context = TimingContext(

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -101,28 +101,82 @@ class TestContexts(TestCase):
 
     def test_timing_context(self):
         from neon_data_models.models.base.contexts import TimingContext
+        import json
+        
         default = TimingContext()
         self.assertIsNone(default.model_dump()['handle_utterance'])
 
         # Alias handling
         test_time = time()
-        test_duration = 0.00001234
         timing = TimingContext(transcribed=test_time,
-                               text_parsers=test_duration)
+                               text_parsers=0.0001)
 
         # Type casting
         self.assertIsInstance(timing.handle_utterance, datetime)
-        self.assertAlmostEqual(timing.handle_utterance.timestamp(), test_time, 5)
+        self.assertAlmostEqual(timing.handle_utterance.timestamp(), 
+                               test_time, 0)
         self.assertIsInstance(timing.transform_utterance, timedelta)
-        self.assertAlmostEqual(timing.transform_utterance.total_seconds(), test_duration, 5)
+        self.assertAlmostEqual(timing.transform_utterance.total_seconds(),
+                               0, 0)
 
         # Dump/Load
         serialized = timing.model_dump()
         self.assertEqual(serialized['handle_utterance'],
-                         timing.handle_utterance)
+                         timing.handle_utterance.timestamp())
         self.assertEqual(serialized['transform_utterance'],
-                         timing.transform_utterance)
+                         timing.transform_utterance.total_seconds())
         self.assertEqual(timing, TimingContext(**serialized))
+
+        # Create a TimingContext with sample data
+        now = datetime.now()
+        one_second = timedelta(seconds=1)
+        
+        context = TimingContext(
+            audio_begin=now,
+            audio_end=now + one_second,
+            get_stt=one_second,
+            get_tts=timedelta(seconds=2)
+        )
+        
+        # Test serialization
+        serialized = context.model_dump()
+        
+        # Check that datetime fields are converted to timestamps
+        self.assertIsInstance(serialized["audio_begin"], float)
+        self.assertIsInstance(serialized["audio_end"], float)
+        self.assertAlmostEqual(serialized["audio_begin"],
+                                now.timestamp(), delta=0.01)
+        self.assertAlmostEqual(serialized["audio_end"], 
+                               (now + one_second).timestamp(), delta=0.01)
+        
+        # Check that timedelta fields are converted to seconds
+        self.assertIsInstance(serialized["get_stt"], float)
+        self.assertIsInstance(serialized["get_tts"], float)
+        self.assertEqual(serialized["get_stt"], 1.0)
+        self.assertEqual(serialized["get_tts"], 2.0)
+        
+        # Test JSON serialization
+        json_str = json.dumps(serialized)
+        self.assertTrue(json_str)  # Ensure it can be JSON serialized
+        
+        # Test deserialization
+        deserialized_dict = json.loads(json_str)
+        deserialized = TimingContext(**deserialized_dict)
+        
+        # Check that timestamps are converted back to datetime objects
+        self.assertIsInstance(deserialized.audio_begin, datetime)
+        self.assertIsInstance(deserialized.audio_end, datetime)
+        self.assertAlmostEqual((deserialized.audio_begin - 
+                                now).total_seconds(), 0, delta=0.01)
+        self.assertAlmostEqual((deserialized.audio_end - 
+                                (now + one_second)).total_seconds(), 0,
+                                  delta=0.01)
+        
+        # Check that second values are converted back to timedelta objects
+        self.assertIsInstance(deserialized.get_stt, timedelta)
+        self.assertIsInstance(deserialized.get_tts, timedelta)
+        self.assertEqual(deserialized.get_stt.total_seconds(), 1.0)
+        self.assertEqual(deserialized.get_tts.total_seconds(), 2.0)
 
     def test_klat_context(self):
         from neon_data_models.models.base.contexts import KlatContext

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -259,3 +259,24 @@ class TestMessagebus(TestCase):
 
         # Round-trip serialization results in the same object
         self.assertEqual(extra_context, MessageContext(**serialized))
+    
+        # Test destination validation
+        # Test default initialization
+        default_context = MessageContext()
+        self.assertEqual(default_context.destination, ["skills"])
+        
+        # Test string input gets converted to list
+        string_context = MessageContext(destination="test")
+        self.assertEqual(string_context.destination, ["test"])
+        
+        # Test list input remains a list
+        list_context = MessageContext(destination=["test1", "test2"])
+        self.assertEqual(list_context.destination, ["test1", "test2"])
+        
+        # Test serialization/deserialization
+        serialized = string_context.model_dump()
+        self.assertEqual(serialized["destination"], ["test"])
+        
+        # Test round-trip
+        deserialized = MessageContext(**serialized)
+        self.assertEqual(deserialized.destination, ["test"])

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -101,6 +101,8 @@ class TestContexts(TestCase):
 
     def test_timing_context(self):
         from neon_data_models.models.base.contexts import TimingContext
+        from datetime import datetime, timedelta, timezone
+
         import json
         
         default = TimingContext()
@@ -177,6 +179,163 @@ class TestContexts(TestCase):
         self.assertIsInstance(deserialized.get_tts, timedelta)
         self.assertEqual(deserialized.get_stt.total_seconds(), 1.0)
         self.assertEqual(deserialized.get_tts.total_seconds(), 2.0)
+
+        
+        # Test invalid type for datetime field (string)
+        with self.assertRaises(ValidationError) as context:
+            TimingContext(audio_begin="not a timestamp or datetime")
+        self.assertIn("audio_begin", str(context.exception))
+        
+        # Test invalid type for datetime field (dict)
+        with self.assertRaises(ValidationError) as context:
+            TimingContext(client_sent={"invalid": "value"})
+        self.assertIn("client_sent", str(context.exception))
+        
+        # Test invalid type for timedelta field
+        with self.assertRaises(ValidationError) as context:
+            TimingContext(get_stt="invalid")
+        
+        # Create a context with all fields populated
+        now = datetime.now(tz=timezone.utc)
+        delta = timedelta(seconds=0.5)
+        
+        timing = TimingContext(
+            # Datetime fields
+            audio_begin=now,
+            audio_end=now + delta,
+            client_sent=now + delta * 2,
+            gradio_sent=now + delta * 3,
+            handle_utterance=now + delta * 4,
+            response_sent=now + delta * 5,
+            speech_start=now + delta * 6,
+            
+            # Timedelta fields
+            get_stt=delta,
+            get_tts=delta * 2,
+            iris_input_handling=delta * 3,
+            mq_response_handler=delta * 4,
+            mq_from_core=delta * 5,
+            mq_from_client=delta * 6,
+            mq_input_handler=delta * 7,
+            client_to_core=delta * 8,
+            client_from_core=delta * 9,
+            save_transcript=delta * 10,
+            transform_audio=delta * 11,
+            transform_utterance=delta * 12,
+            wait_in_queue=delta * 13
+        )
+        
+        # Verify all fields are properly typed
+        self.assertIsInstance(timing.audio_begin, datetime)
+        self.assertIsInstance(timing.audio_end, datetime)
+        self.assertIsInstance(timing.client_sent, datetime)
+        self.assertIsInstance(timing.gradio_sent, datetime)
+        self.assertIsInstance(timing.handle_utterance, datetime)
+        self.assertIsInstance(timing.response_sent, datetime)
+        self.assertIsInstance(timing.speech_start, datetime)
+        
+        self.assertIsInstance(timing.get_stt, timedelta)
+        self.assertIsInstance(timing.get_tts, timedelta)
+        self.assertIsInstance(timing.iris_input_handling, timedelta)
+        self.assertIsInstance(timing.mq_response_handler, timedelta)
+        self.assertIsInstance(timing.mq_from_core, timedelta)
+        self.assertIsInstance(timing.mq_from_client, timedelta)
+        self.assertIsInstance(timing.mq_input_handler, timedelta)
+        self.assertIsInstance(timing.client_to_core, timedelta)
+        self.assertIsInstance(timing.client_from_core, timedelta)
+        self.assertIsInstance(timing.save_transcript, timedelta)
+        self.assertIsInstance(timing.transform_audio, timedelta)
+        self.assertIsInstance(timing.transform_utterance, timedelta)
+        self.assertIsInstance(timing.wait_in_queue, timedelta)
+        
+        # Test serialization/deserialization with all fields
+        serialized = timing.model_dump()
+        deserialized = TimingContext(**serialized)
+        self.assertEqual(timing, deserialized)
+
+
+        # Zero timestamp
+        zero_time = TimingContext(audio_begin=0)
+        self.assertEqual(zero_time.audio_begin, 
+                         datetime.fromtimestamp(0, tz=timezone.utc))
+        
+        # Negative timestamp (represents dates before 1970)
+        neg_time = TimingContext(audio_begin=-86400)  # One day before epoch
+        self.assertEqual(neg_time.audio_begin, 
+                         datetime.fromtimestamp(-86400, tz=timezone.utc))
+        
+        # Very large timestamp
+        future_time = TimingContext(audio_begin=2147483647)  # Year 2038
+        self.assertEqual(future_time.audio_begin, 
+                         datetime.fromtimestamp(2147483647, tz=timezone.utc))
+        
+        # Zero timedelta
+        zero_delta = TimingContext(get_stt=0)
+        self.assertEqual(zero_delta.get_stt, timedelta(0))
+        
+        # Negative timedelta
+        neg_delta = TimingContext(get_stt=-1.5)
+        self.assertEqual(neg_delta.get_stt, timedelta(seconds=-1.5))
+
+
+        now = datetime.now(tz=timezone.utc)
+        timestamp = now.timestamp()
+        
+        # Test with timestamp input
+        timestamp_input = TimingContext(audio_begin=timestamp)
+        self.assertIsInstance(timestamp_input.audio_begin, datetime)
+        self.assertAlmostEqual(timestamp_input.audio_begin.timestamp(), 
+                               timestamp, places=3)
+        
+        # Test with datetime input
+        datetime_input = TimingContext(audio_begin=now)
+        self.assertIsInstance(datetime_input.audio_begin, datetime)
+        self.assertAlmostEqual(datetime_input.audio_begin.timestamp(), 
+                               timestamp, places=3)
+        
+        # Compare both inputs
+        self.assertAlmostEqual(timestamp_input.audio_begin.timestamp(),
+                               datetime_input.audio_begin.timestamp(), 
+                               places=3)
+        
+        # Test with timedelta object vs number of seconds
+        delta = timedelta(seconds=1.5)
+        delta_input = TimingContext(get_stt=delta)
+        seconds_input = TimingContext(get_stt=1.5)
+        
+        self.assertEqual(delta_input.get_stt, delta)
+        self.assertEqual(seconds_input.get_stt, delta)
+
+
+        timestamp = datetime.now(tz=timezone.utc).timestamp()
+        
+        # Test transcribed alias for handle_utterance
+        with_transcribed = TimingContext(transcribed=timestamp)
+        self.assertIsInstance(with_transcribed.handle_utterance, datetime)
+        self.assertAlmostEqual(with_transcribed.handle_utterance.timestamp(), 
+                               timestamp, places=3)
+        
+        # Test text_parsers alias for transform_utterance
+        with_text_parsers = TimingContext(text_parsers=1.5)
+        self.assertIsInstance(with_text_parsers.transform_utterance, timedelta)
+        self.assertEqual(with_text_parsers.transform_utterance, 
+                         timedelta(seconds=1.5))
+        
+        # Test both aliases together
+        with_both = TimingContext(transcribed=timestamp, text_parsers=2.5)
+        self.assertIsInstance(with_both.handle_utterance, datetime)
+        self.assertIsInstance(with_both.transform_utterance, timedelta)
+        self.assertAlmostEqual(with_both.handle_utterance.timestamp(), 
+                               timestamp, places=3)
+        self.assertEqual(with_both.transform_utterance, 
+                         timedelta(seconds=2.5))
+        
+        # Ensure serialized data doesn't contain the old field names
+        serialized = with_both.model_dump()
+        self.assertIn("handle_utterance", serialized)
+        self.assertIn("transform_utterance", serialized)
+        self.assertNotIn("transcribed", serialized)
+        self.assertNotIn("text_parsers", serialized)
 
     def test_klat_context(self):
         from neon_data_models.models.base.contexts import KlatContext

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -340,10 +340,29 @@ class TestContexts(TestCase):
     def test_klat_context(self):
         from neon_data_models.models.base.contexts import KlatContext
         with self.assertRaises(ValidationError):
-            KlatContext()
+            KlatContext(sid=None)
 
         minimal_ctx = KlatContext(cid="conversation", sid="shout")
         self.assertEqual(minimal_ctx, KlatContext(**minimal_ctx.model_dump()))
+        
+        # Test messageID normalization to sid
+        message_id_ctx = KlatContext(cid="conversation", messageID="message_id_value")
+        self.assertEqual(message_id_ctx.sid, "message_id_value")
+        self.assertEqual(message_id_ctx.cid, "conversation")
+        
+        # Test serialization with normalized field
+        serialized = message_id_ctx.model_dump()
+        self.assertEqual(serialized["sid"], "message_id_value")
+        self.assertNotIn("messageID", serialized)
+        
+        # Test round-trip serialization
+        deserialized = KlatContext(**serialized)
+        self.assertEqual(deserialized.sid, "message_id_value")
+        self.assertEqual(deserialized, message_id_ctx)
+        
+        # Test that sid takes precedence when both fields are provided
+        both_fields_ctx = KlatContext(cid="conversation", sid="shout_id", messageID="message_id_value")
+        self.assertEqual(both_fields_ctx.sid, "shout_id")
 
     def test_mq_context(self):
         from neon_data_models.models.base.contexts import MQContext

--- a/tests/models/test_client.py
+++ b/tests/models/test_client.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -45,6 +45,9 @@ class TestDatabase(TestCase):
                   "preferred_name": "tester",
                   "dob": "2001-01-01",
                   "email": "developers@neon.ai",
+                  "avatar_url": "https://example.com/avatar.jpg",
+                  "about": "Test user biography",
+                  "phone": "555-123-4567",
                   "extra_key": "This should be removed by validation"
                   },
             language={"input": ["en-us", "uk-ua"],
@@ -67,6 +70,17 @@ class TestDatabase(TestCase):
             extras_keys = getattr(valid_with_extras, section).model_dump().keys()
             self.assertEqual(default_keys, extras_keys)
 
+        # Testing user fields specifically
+        self.assertEqual(valid_with_extras.user.first_name, "Daniel")
+        self.assertEqual(valid_with_extras.user.middle_name, "James")
+        self.assertEqual(valid_with_extras.user.last_name, "McKnight")
+        self.assertEqual(valid_with_extras.user.preferred_name, "tester")
+        self.assertEqual(valid_with_extras.user.email, "developers@neon.ai")
+        self.assertEqual(valid_with_extras.user.avatar_url, "https://example.com/avatar.jpg")
+        self.assertEqual(valid_with_extras.user.about, "Test user biography")
+        self.assertEqual(valid_with_extras.user.phone, "555-123-4567")
+        self.assertEqual(valid_with_extras.user.dob, date(2001, 1, 1))
+
         # Validation errors
         with self.assertRaises(ValidationError):
             NeonUserConfig(units={"time": 13})
@@ -83,6 +97,52 @@ class TestDatabase(TestCase):
 
         config = NeonUserConfig(user={"dob": "2001-01-01"})
         self.assertIsInstance(config.user.dob, date)
+
+    def test_user_config(self):
+        """Test the _UserConfig class specifically."""
+        from neon_data_models.models.user.database import _UserConfig
+        
+        # Test default values
+        default_config = _UserConfig()
+        self.assertEqual(default_config.first_name, "")
+        self.assertEqual(default_config.middle_name, "")
+        self.assertEqual(default_config.last_name, "")
+        self.assertEqual(default_config.preferred_name, "")
+        self.assertEqual(default_config.email, "")
+        self.assertEqual(default_config.avatar_url, "")
+        self.assertEqual(default_config.about, "")
+        self.assertEqual(default_config.phone, "")
+        self.assertIsNone(default_config.dob)
+        
+        # Test setting values
+        user_config = _UserConfig(
+            first_name="John",
+            middle_name="Doe",
+            last_name="Smith",
+            preferred_name="Johnny",
+            email="john.smith@example.com",
+            avatar_url="https://example.com/avatar.jpg",
+            about="Test biography",
+            phone="555-987-6543",
+            dob=date(1990, 1, 1)
+        )
+        self.assertEqual(user_config.first_name, "John")
+        self.assertEqual(user_config.middle_name, "Doe")
+        self.assertEqual(user_config.last_name, "Smith")
+        self.assertEqual(user_config.preferred_name, "Johnny")
+        self.assertEqual(user_config.email, "john.smith@example.com")
+        self.assertEqual(user_config.avatar_url, "https://example.com/avatar.jpg")
+        self.assertEqual(user_config.about, "Test biography")
+        self.assertEqual(user_config.phone, "555-987-6543")
+        self.assertEqual(user_config.dob, date(1990, 1, 1))
+        
+        # Test dob validator
+        legacy_config = _UserConfig(dob="YYYY/MM/DD")
+        self.assertIsNone(legacy_config.dob)
+        
+        # Test valid date string
+        valid_date_config = _UserConfig(dob="2000-12-31")
+        self.assertEqual(valid_date_config.dob, date(2000, 12, 31))
 
     def test_user(self):
         from neon_data_models.enum import AccessRoles

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
# Description
Add request models for Neon MQ API with associated Messagebus models
Updates `BaseModel` to serialize `datetime` objects to `float` for JSON/MQ compat.
Update Klat and MQ contexts for pyklatchat SIO message compat.
Updates User DoB input handling to support default `YYYY/MM/DD` strings as `None` for backwards-compat. (Iris)
Updates `session` context to use a default value in place of `None`
Updates license notices to 2025

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->