### PR TITLE
Implement MQ models for chatbots API

### DIFF
--- a/neon_data_models/enum.py
+++ b/neon_data_models/enum.py
@@ -106,3 +106,11 @@ class CcaiState(IntEnum):
     VOTE = 3  # Voting on responses
     PICK = 4  # Proctor will select response
     WAIT = 5  # Bot is waiting for the proctor to ask them to respond (not participating)
+
+
+class CcaiControl(Enum):
+    PROMPT_REGEX = r"^!PROMPT:"
+    SAVE_PROMPT_RESULTS = "!MSG:SAVE_PROMPT_RESULTS"
+    CREATE_PROMPT = "!MSG:CREATE_PROMPT"
+    START_AUTO_PROMPTS = "!START_AUTO_PROMPTS"
+    STOP_AUTO_PROMPTS = "!STOP_AUTO_PROMPTS"

--- a/neon_data_models/enum.py
+++ b/neon_data_models/enum.py
@@ -24,7 +24,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from enum import IntEnum
+from enum import Enum, IntEnum
 
 
 class AccessRoles(IntEnum):
@@ -92,3 +92,17 @@ class Weekdays(IntEnum):
     FRI = 4
     SAT = 5
     SUN = 6
+
+
+class SubmindStatus(Enum):
+    BANNED = "banned"
+    ACTIVE = "active"
+
+
+class CcaiState(IntEnum):
+    IDLE = 0  # No active prompt
+    RESP = 1  # Gathering responses to prompt
+    DISC = 2  # Discussing responses
+    VOTE = 3  # Voting on responses
+    PICK = 4  # Proctor will select response
+    WAIT = 5  # Bot is waiting for the proctor to ask them to respond (not participating)

--- a/neon_data_models/enum.py
+++ b/neon_data_models/enum.py
@@ -95,20 +95,29 @@ class Weekdays(IntEnum):
 
 
 class SubmindStatus(Enum):
+    """
+    Defines status of a submind in a particular conversation
+    """
     BANNED = "banned"
     ACTIVE = "active"
 
 
 class CcaiState(IntEnum):
+    """
+    Defines status of a conversation where a CCAI is operating
+    """
     IDLE = 0  # No active prompt
     RESP = 1  # Gathering responses to prompt
     DISC = 2  # Discussing responses
     VOTE = 3  # Voting on responses
     PICK = 4  # Proctor will select response
-    WAIT = 5  # Bot is waiting for the proctor to ask them to respond (not participating)
+    WAIT = 5  # Bot is waiting for an invitation to participate
 
 
 class CcaiControl(Enum):
+    """
+    Defines control messages for a CCAI conversation
+    """
     PROMPT_REGEX = r"^!PROMPT:"
     SAVE_PROMPT_RESULTS = "!MSG:SAVE_PROMPT_RESULTS"
     CREATE_PROMPT = "!MSG:CREATE_PROMPT"

--- a/neon_data_models/models/api/chatbots.py
+++ b/neon_data_models/models/api/chatbots.py
@@ -1,0 +1,55 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2025 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import List, Optional
+from datetime import datetime, timezone
+from pydantic import Field
+from neon_data_models.models.base import BaseModel
+from neon_data_models.types import BotType
+
+
+class ConnectedSubmind(BaseModel):
+    service_name: str = Field(
+        description="Name of the submind service (not its UID)")
+    attached_cids: List[str] = Field(
+        default=[], alias="cids",
+        description="List of conversation IDs the submind is participating in")
+    version: Optional[str] = Field(
+        default=None,
+        description="Version of chatbot-core the submind is using")
+    supports_raw_conversation: bool = Field(
+        default=False,
+        description="True if the submind will handle all conversation shouts")
+    last_ping: datetime = Field(
+        default_factory=lambda: datetime.now(tz=timezone.utc),
+        description="Last time the submind pinged the observer")
+
+    bot_type: BotType = Field(
+        deprecated=True, default="submind",
+        description="Type of bot (always `submind` in this context)")
+
+
+__all__ = [ConnectedSubmind.__name__]

--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -47,6 +47,13 @@ class LLMPersonaIdentity(BaseModel):
         if self.user_id:
             persona_id += f"_{self.user_id}"
         return persona_id
+    
+    @model_validator(mode='before')
+    @classmethod
+    def validate_inputs(cls, values):
+        # MQ API uses `persona_name` here
+        values.setdefault('name', values.get('persona_name'))
+        return values
 
 
 class LLMPersona(LLMPersonaIdentity):

--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -36,7 +36,8 @@ class LLMPersonaIdentity(BaseModel):
     """
     Defines metadata for a unique persona.
     """
-    name: str = Field(description="Unique name for this persona")
+    name: str = Field(alias="persona_name", 
+                      description="Unique name for this persona")
     user_id: Optional[str] = Field(
         None, description="`user_id` of the user who created this persona.")
 
@@ -47,13 +48,6 @@ class LLMPersonaIdentity(BaseModel):
         if self.user_id:
             persona_id += f"_{self.user_id}"
         return persona_id
-    
-    @model_validator(mode='before')
-    @classmethod
-    def validate_inputs(cls, values):
-        # MQ API uses `persona_name` here
-        values.setdefault('name', values.get('persona_name'))
-        return values
 
 
 class LLMPersona(LLMPersonaIdentity):

--- a/neon_data_models/models/api/mq/__init__.py
+++ b/neon_data_models/models/api/mq/__init__.py
@@ -24,6 +24,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from neon_data_models.models.api.mq.chatbots import *
 from neon_data_models.models.api.mq.llm import *
-from neon_data_models.models.api.mq.users import *
 from neon_data_models.models.api.mq.neon import *
+from neon_data_models.models.api.mq.users import *

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -117,7 +117,7 @@ class ChatbotsMqResponse(KlatContext, MQContext):
         description="State of the CCAI conversation associated with the shout")
     is_announcement: bool = Field(
         default=False, alias="isAnnouncement",
-        description="`1` if the shout is an announcement")
+        description="True if the shout is an announcement")
     time_created: datetime = Field(
         default= datetime.now(tz=timezone.utc), alias="timeCreated",
         description="Timestamp when the shout was created")
@@ -160,6 +160,7 @@ class ChatbotsMqResponse(KlatContext, MQContext):
         by_alias = {}
         if 'by_alias' not in kwargs:
             by_alias = super().model_dump(by_alias=True, **kwargs)
+            by_alias['isAnnouncement'] = '1' if self.is_announcement else '0'
         
         return {**super().model_dump(**kwargs), **by_alias}
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -389,11 +389,11 @@ class ChatbotsMqSubmindConnection(MQContext):
     @model_validator(mode='before')
     @classmethod
     def validate_context(cls, values):
-        if "context" in values:
+        if "context" in values and isinstance(values["context"], dict):
             values["context"].setdefault("service_name",
                                           values.get("user_id").rsplit('-',
                                                                         1)[0])
-            return values
+        return values
 
 
 class ChatbotsMqSubmindDisconnection(MQContext):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -153,6 +153,9 @@ class ChatbotSavePrompt(ChatbotResponse):
 
 
 class ChatbotNewPrompt(ChatbotResponse):
+    prompt_id: str = Field(
+        description="ID of the CCAI prompt associated with the shout"
+    )
     user_id: Optional[str] = Field(default=None)
     prompt_text: str = Field(default="")
     context: Optional[dict] = Field(default=None)

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -68,7 +68,7 @@ class ChatbotRequest(KlatContext, MQContext):
                 sio_message.get("userID"),
             message_text=sio_message["messageText"],
             from_bot=sio_message.get("bot") == 1,
-            prompt_id = sio_message.get("promptId"),
+            prompt_id = sio_message.get("promptID"),
             prompt_state=sio_message.get("promptState"),
             time_created=sio_message["timeCreated"],
             recipient=sio_message.get("recipient"),
@@ -80,8 +80,9 @@ class ChatbotRequest(KlatContext, MQContext):
         data = super().model_dump(**kwargs)
         # Add the 'bot' parameter as '1' or '0' string for backwards compatibility
         data["bot"] = "1" if self.from_bot else "0"
-        # Add `messageText` for backwards-compat.
+        # Add parameters for backwards-compat.
         data["messageText"] = self.message_text
+        data["nick"] = self.username
         return data
 
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -138,7 +138,7 @@ class ChatbotSavePrompt(ChatbotResponse):
 
 
 class ChatbotNewPrompt(ChatbotResponse):
-    user_id = None
+    user_id: Optional[str] = Field(default=None)
     prompt_text: str = Field(default="")
     context: Optional[dict] = None
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -272,15 +272,34 @@ class ChatbotsMqConfiguredPersonasResponse(MQContext):
 
 
 class ChatbotsMqPromptsDataRequest(MQContext):
-    pass
+    """
+    Convenience class. The message payload here is just `MQContext`.
+    """
 
 
 class ChatbotsMqPromptsDataResponse(MQContext):
-    pass
+    records: List[str] = Field(description="List of configured prompts")
+    context: dict = Field(deprecated=True)
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_context(cls, values):
+        # Deprecated context handling for backwards-compat.
+        if 'context' not in values and 'message_id' in values:
+            values['context'] = {"mq": {"message_id": values['message_id']}}
+        return values
+    
+    @classmethod
+    def from_prompt_data_request(cls, data: dict,
+                               request: ChatbotsMqPromptsDataRequest):
+        return cls(**data, message_id=request.message_id,
+                   routing_key=request.routing_key)
 
 
 __all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,
            ChatbotsMqSavePrompt.__name__, ChatbotsMqNewPrompt.__name__,
            ChatbotsMqSubmindsState.__name__, 
            ChatbotsMqConfiguredPersonasRequest.__name__,
-           ChatbotsMqConfiguredPersonasResponse.__name__]
+           ChatbotsMqConfiguredPersonasResponse.__name__,
+           ChatbotsMqPromptsDataRequest.__name__,
+           ChatbotsMqPromptsDataResponse.__name__]

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -128,7 +128,16 @@ class ChatbotResponse(KlatContext, MQContext):
 
 
 class PromptCompletedContext(BaseModel):
-    prompt: Dict[str, str]
+    prompt: ChatbotRequest
+    is_active: bool
+    prompt_text: str
+    available_subminds: List[str]
+    state: int
+    participating_subminds: List[str]
+    proposed_responses: Dict[str, str]
+    submind_opinions: Dict[str, str]
+    votes: Dict[str, str]
+    votes_per_submind: Dict[str, List[str]]
     winner: str = ""
 
 class ChatbotSavePrompt(ChatbotResponse):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -137,8 +137,6 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
     #     description="If true, the Proctor will ignore this message")
     # no_save: bool = Field(default=False, deprecated=True,
     #                       description="If true, this message will be ignored")
-    # created_on: datetime = Field(default=datetime.now(timezone.utc),
-    #                              description="Timestamp of response")
     # to_discussion: bool = Field(default=False, deprecated=True)
 
     @model_validator(mode='before')
@@ -192,39 +190,34 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
 
 
 class PromptCompletedContext(BaseModel):
-    prompt: Optional[ChatbotsMqRequest] = None
-    is_active: bool = False
-    prompt_text: str
-    available_subminds: List[str] = []
-    state: Optional[int] = None
-    participating_subminds: List[str] = []
-    proposed_responses: Dict[str, str] = {}
-    submind_opinions: Dict[str, str] = {}
-    votes: Dict[str, str] = {}
-    votes_per_submind: Dict[str, List[str]] = {}
-    winner: str = ""
+    prompt: Optional[ChatbotsMqRequest] = Field(
+        default=None, description="Original request containing the prompt")
+    is_active: bool = Field(
+        default=False, description="True if a response has not yet been chosen")
+    prompt_text: str = Field(description="The string prompt that is completed")
+    available_subminds: List[str] = Field(
+        default=[], description="List of subminds available to participate")
+    state: Optional[int] = Field(default=None)  # TODO: Define
+    participating_subminds: List[str] = Field(
+        default=[], description="List of subminds participating in the prompt")
+    proposed_responses: Dict[str, str] = Field(
+        default={}, description="Dict of nick to proposal")
+    
+    # In the future, there will be a list of these for multi-round discussion
+    submind_opinions: Dict[str, str] = Field(
+        default={}, description="Dict of nick to discussion")
+
+    votes: Dict[str, str] = Field(default={},
+                                  description="Dict of nick to vote")
+    votes_per_submind: Dict[str, List[str]] = Field(
+        default={}, description="Dict of nick to list of received votes")
+    winner: str = Field(default="", description="Selected winner")
 
 
 class ChatbotsMqSavePrompt(ChatbotsMqSubmindResponse):
-    prompt_id: str = Field(
-        default="",
-        description="ID of the CCAI prompt associated with the shout")
-    prompt_text: str = Field(default="")
-    # created_on: str = Field(default="", deprecated=True,
-    #                         description="String date of prompt creation.")
-    context: PromptCompletedContext = Field(alias="conversation_context")
-
-    # @model_validator(mode='before')
-    # @classmethod
-    # def validate_context(cls, values):
-    #     # if "context" in values and not values["context"]:
-    #     #     # Pop to replace with `conversation_context` or fail
-    #     #     values.pop("context")
-
-    #     # TODO: Patching invalid input for backwards-compat.
-    #     if "created_on" in values and values["created_on"] is None:
-    #         values.pop("created_on")
-    #     return values
+    context: PromptCompletedContext = Field(
+        alias="conversation_context",
+        description="Definition of the completed discussion")
     
     def model_dump(self, **kwargs):
         return ChatbotsMqSubmindResponse.model_dump(self, **kwargs)
@@ -234,20 +227,18 @@ class ChatbotsMqNewPrompt(ChatbotsMqSubmindResponse):
     prompt_id: str = Field(
         description="ID of the CCAI prompt associated with the shout"
     )
-    user_id: Optional[str] = Field(default=None)
-    prompt_text: str = Field(default="")
-    context: Optional[dict] = Field(default=None,
+    user_id: Optional[str] = Field(default=None, alias="nick",
+                                   description="User ID of the proctor")
+    prompt_text: str = Field(description="The new prompt being discussed")
+    context: Optional[dict] = Field(default=None, deprecated=True,
                                     alias="conversation_context")
 
 
     @model_validator(mode='before')
     @classmethod
     def validate_context(cls, values):
-        values.setdefault("context", values.get("conversation_context"))
-        if "prompt_text" in values:
-            values["messageText"] = values.get("prompt_text")
-        if "nick" in values:
-            values.setdefault("user_id", values.get("nick"))
+        values.setdefault("message_text", values.get("shout"))
+        values.setdefault("user_id", values.get("nick"))
         return values
     
     def model_dump(self, **kwargs):
@@ -265,6 +256,7 @@ class ChatbotsMqResponse:
                                             ChatbotsMqSubmindResponse]:
         message_text = kwargs.get("message_text") or kwargs.get("messageText") \
             or kwargs.get("shout")
+        kwargs['message_text'] = message_text
         
         if message_text == CcaiControl.SAVE_PROMPT_RESULTS.value:
             return ChatbotsMqSavePrompt(**kwargs)
@@ -277,31 +269,24 @@ class ChatbotsMqResponse:
     #                        ChatbotsMqSubmindResponse])
 
 
-class ConnectedSubmind(MQContext):
+class ConnectedSubmind(BaseModel):
     bot_type: BotType
     service_name: str
-    cid: str = Field(deprecated=True)
-    dom: str = Field(deprecated=True)
-    conversation_state: CcaiState
-    responded_shout: Optional[str] = Field(deprecated=True)
-    shout: Literal["chatbot state"] = Field(deprecated=True)
-    context: Dict[str, Any]  # TODO: Refactor?
-    prompt_id: Optional[str] = Field(deprecated=True)
-    omit_reply: bool = Field(deprecated=True)
-    no_save: bool = Field(deprecated=True)
-    attached_cids: List[str]
-    supports_raw_shouts: bool  # TODO: Refactor?
-    last_ping: datetime
-
-    @model_validator(mode='before')
-    @classmethod
-    def validate_context(cls, values):
-        # TODO: Mark as deprecated
-        # if values.get('bot_type') in ('proctor', 'observer'):
-        #     values['bot_type'] = 'facilitator'
-        if values.get('shout') == 'hello':
-            values['shout'] = 'chatbot state'
-        return values
+    # cid: str = Field(deprecated=True)
+    # dom: str = Field(deprecated=True)
+    # conversation_state: CcaiState
+    # responded_shout: Optional[str] = Field(deprecated=True)
+    # shout: Literal["chatbot state"] = Field(deprecated=True)
+    # context: Dict[str, Any]
+    # prompt_id: Optional[str] = Field(deprecated=True)
+    # omit_reply: bool = Field(deprecated=True)
+    # no_save: bool = Field(deprecated=True)
+    attached_cids: List[str] = Field(
+        description="List of conversation IDs the submind is participating in")
+    supports_raw_shouts: bool = Field(
+        description="True if the submind will handle all conversation shouts")  # TODO: Refactor?
+    last_ping: datetime = Field(
+        description="Last time the submind pinged the observer")
 
 
 class ChatbotsMqSubmindsState(MQContext):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -128,11 +128,13 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
         description="Name of the service originating the shout")
     bot_type: BotType = Field(default=None, deprecated=True,
                               description="Type of submind sending the shout")
-
+    participating_subminds: Optional[List[str]] = Field(
+        default=[], deprecated=True,
+        description="List of subminds participating in the shout")
     # service_name: Any = Field(default=None, deprecated=True)
-    context: Optional[dict] = Field(
-        default=None, deprecated=True,
-        description="Context used for Klat Server backwards-compat.")
+    # context: Optional[dict] = Field(
+    #     default=None, deprecated=True,
+    #     description="Context used for Klat Server backwards-compat.")
     # dom: Any = Field(default=None, deprecated=True,
     #                  description="Domain of this conversation")
     # omit_reply: bool = Field(

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -220,6 +220,9 @@ class ChatbotsMqSubmindsState(MQContext):
         submind_id: str = Field(description="Connected submind's user_id")
         status: SubmindStatus = Field(
             description="Subminds's status in a particular conversation")
+
+    msg_type: Literal["subminds_state"] = Field(
+        "subminds_state", description="Message type for SIO", deprecated=True)
     subminds_per_cid: Dict[str, List[SubmindState]]
     connected_subminds: Dict[str, ConnectedSubmind]
     cid_submind_bans: Dict[str, List[str]] = Field(

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -134,7 +134,7 @@ class ChatbotsMqResponse(KlatContext, MQContext):
 
     @model_validator(mode='before')
     @classmethod
-    def validate_uid(cls, values):
+    def validate_inputs(cls, values):
         # Some references use different keys
         # TODO: prevent `None` values from being added here in place of missing
         #  keys
@@ -143,6 +143,7 @@ class ChatbotsMqResponse(KlatContext, MQContext):
         values.setdefault("messageText", values.get("shout"))
         values.setdefault("repliedMessage", values.get("responded_shout"))
         values.setdefault("timeCreated", values.get("time"))
+        return values
 
     class Config:
         # For aliased fields, accept either the canonical name OR the alias

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -119,7 +119,6 @@ class ChatbotsMqResponse(KlatContext, MQContext):
         default='0', alias="isAnnouncement",
         description="`1` if the shout is an announcement")
     time_created: datetime = Field(
-        alias="time",
         default= datetime.now(tz=timezone.utc), alias="timeCreated",
         description="Timestamp when the shout was created")
     source: str = Field(
@@ -136,13 +135,14 @@ class ChatbotsMqResponse(KlatContext, MQContext):
     @model_validator(mode='before')
     @classmethod
     def validate_uid(cls, values):
-        # Some references use `nick` instead of `user_id` or `userID`
-        values.setdefault("user_id", values.get("nick"))
+        # Some references use different keys
+        # TODO: prevent `None` values from being added here in place of missing
+        #  keys
+        values.setdefault("userID", values.get("nick"))
 
-        # Some reference use `shout` instead of `message_text`
-        values.setdefault("message_text", values.get("shout"))
-
-        values.setdefault("replied_message", values.get("responded_shout"))
+        values.setdefault("messageText", values.get("shout"))
+        values.setdefault("repliedMessage", values.get("responded_shout"))
+        values.setdefault("timeCreated", values.get("time"))
 
     class Config:
         # For aliased fields, accept either the canonical name OR the alias

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -125,12 +125,12 @@ class ChatbotsMqResponse(KlatContext, MQContext):
         default="klat_observer",
         description="Name of the service originating the shout")
     
-    bot_type = Field(default=None, deprecated=True)
-    service_name = Field(default=None, deprecated=True)
-    conversatino_state = Field(default=None, deprecated=True)
-    context = Field(default=None, deprecated=True)
-    omit_reply = Field(default=None, deprecated=True)
-    no_save = Field(default=None, deprecated=True)
+    bot_type: BotType = Field(default=None, deprecated=True)
+    service_name: Any = Field(default=None, deprecated=True)
+    conversation_state: Any = Field(default=None, deprecated=True)
+    context: dict = Field(default=None, deprecated=True)
+    omit_reply: Any = Field(default=None, deprecated=True)
+    no_save: Any = Field(default=None, deprecated=True)
 
     @model_validator(mode='before')
     @classmethod

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -444,6 +444,11 @@ class ChatbotsMqSubmindGlobalBan(MQContext):
         populate_by_name = True
 
 
+class ChatbotsMqSubmindResponseError(MQContext):
+    message: Optional[str] = Field(default=None, alias="msg",
+                                    description="Error message")
+
+
 __all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,
            ChatbotsMqSubmindResponse.__name__, ChatbotsMqSavePrompt.__name__,
            ChatbotsMqNewPrompt.__name__, ChatbotsMqSubmindsState.__name__, 
@@ -456,4 +461,5 @@ __all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,
            ChatbotsMqSubmindInvitation.__name__,
            ChatbotsMqUpdateParticipatingSubminds.__name__,
            ChatbotsMqSubmindConversationBan.__name__,
-           ChatbotsMqSubmindGlobalBan.__name__,]
+           ChatbotsMqSubmindGlobalBan.__name__,
+           ChatbotsMqSubmindResponseError.__name__,]

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -195,15 +195,7 @@ class ChatbotsMqSavePrompt(ChatbotsMqResponse):
         description="ID of the CCAI prompt associated with the shout")
     prompt_text: str = Field(default="")
     created_on: str = Field(default="")
-    context: PromptCompletedContext = Field()
-    
-    @model_validator(mode='before')
-    @classmethod
-    def validate_context(cls, values):
-        # If context is empty, remove it from the values so validation passes
-        if "context" in values and not values["context"]:
-            values.pop("context")
-        return values
+    context: PromptCompletedContext = Field(alias="conversation_context")
 
     def model_dump(self, **kwargs):
         return ChatbotsMqResponse.model_dump(self, **kwargs)

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -113,8 +113,8 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
     prompt_id: Optional[str] = Field(
         default=None, alias="promptID",
         description="ID of the CCAI prompt associated with the shout")
-    prompt_state: int = Field(
-        default=CcaiState.IDLE.value,  # Default for backwards-compat. with cb-observer
+    prompt_state: CcaiState = Field(
+        default=CcaiState.IDLE,  # Default for backwards-compat. with cb-observer
         deprecated=True, alias="conversation_state",
         description="State of the CCAI conversation associated with the shout")
     is_announcement: bool = Field(

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -135,18 +135,19 @@ class ChatbotsMqResponse(KlatContext, MQContext):
     @model_validator(mode='before')
     @classmethod
     def validate_inputs(cls, values):
-        # Some references use different keys
-        # TODO: prevent `None` values from being added here in place of missing
-        #  keys
-        values.setdefault("userID", values.get("nick"))
+        if isinstance(values, dict):
+            # Some references use different keys
+            # TODO: prevent `None` values from being added here in place of missing
+            #  keys
+            values.setdefault("userID", values.get("nick"))
 
-        values.setdefault("messageText", values.get("shout"))
-        values.setdefault("repliedMessage", values.get("responded_shout"))
-        values.setdefault("timeCreated", values.get("time"))
+            values.setdefault("messageText", values.get("shout"))
+            values.setdefault("repliedMessage", values.get("responded_shout"))
+            values.setdefault("timeCreated", values.get("time"))
 
-        # TODO: Mark as deprecated
-        if values.get('bot_type') in ('proctor', 'observer'):
-            values['bot_type'] = 'facilitator'
+            # TODO: Mark as deprecated
+            if values.get('bot_type') in ('proctor', 'observer'):
+                values['bot_type'] = 'facilitator'
 
         return values
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -64,7 +64,8 @@ class ChatbotRequest(KlatContext, MQContext):
         return ChatbotRequest(
             **klat_context.model_dump(exclude_none=True),
             **mq_context.model_dump(exclude_none=True),
-            username=sio_message["userDisplayName"],
+            username=sio_message.get("userDisplayName") or \
+                sio_message.get("userID"),
             message_text=sio_message["messageText"],
             from_bot=sio_message.get("bot") == 1,
             prompt_id = sio_message.get("promptId"),

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -146,7 +146,7 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
                           description="If true, this message will be ignored")
     to_discussion: bool = Field(default=False, deprecated=True)
     prompt_state: CcaiState = Field(
-        default=CcaiState.IDLE, deprecated=True, alias="promptState",
+        default=CcaiState.IDLE.value, deprecated=True, alias="promptState",
         description="State of the CCAI conversation associated with the shout")
     
     @model_validator(mode='before')
@@ -287,7 +287,7 @@ class ConnectedSubmind(BaseModel):
     service_name: Optional[str] = Field(default=None,
                                         description="Unique ID of the submind")
     attached_cids: List[str] = Field(
-        default = [], alias="cids",
+        default=[], alias="cids",
         description="List of conversation IDs the submind is participating in")
     version: Optional[str] = Field(
         default=None,
@@ -296,7 +296,7 @@ class ConnectedSubmind(BaseModel):
         default=False,
         description="True if the submind will handle all conversation shouts")
     last_ping: datetime = Field(
-        default = datetime.now(tz=timezone.utc),
+        default=lambda: datetime.now(tz=timezone.utc),
         description="Last time the submind pinged the observer")
 
     bot_type: BotType = Field(

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -143,6 +143,13 @@ class ChatbotsMqResponse(KlatContext, MQContext):
         values.setdefault("messageText", values.get("shout"))
         values.setdefault("repliedMessage", values.get("responded_shout"))
         values.setdefault("timeCreated", values.get("time"))
+
+        # TODO: Mark as deprecated
+        if values.get('bot_type') in ('proctor', 'observer'):
+            values['bot_type'] = 'facilitator'
+        if values.get('shout') == 'hello':
+            values['shout'] = 'chatbot state'
+
         return values
 
     class Config:

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -202,6 +202,16 @@ class ConnectedSubmind(MQContext):
     supports_raw_shouts: bool  # TODO: Refactor?
     last_ping: datetime
 
+    @model_validator(mode='before')
+    @classmethod
+    def validate_context(cls, values):
+        # TODO: Mark as deprecated
+        if values.get('bot_type') in ('proctor', 'observer'):
+            values['bot_type'] = 'facilitator'
+        if values.get('shout') == 'hello':
+            values['shout'] = 'chatbot state'
+        return values
+
 
 class ChatbotsMqSubmindsState(MQContext):
     class SubmindState(BaseModel):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -342,7 +342,7 @@ class ChatbotsMqPromptsDataResponse(MQContext):
 
 
 class ChatbotsMqSubmindConnection(MQContext):
-    nick: str = Field(description="User ID of the submind")
+    user_id: str = Field(description="User ID of the submind", alias="nick")
     time: datetime = Field(
         default= datetime.now(tz=timezone.utc),
         description="Timestamp when the submind last connected")
@@ -352,9 +352,17 @@ class ChatbotsMqSubmindConnection(MQContext):
         default=False,
           description="True if the submind supports unprocessed conversations")
 
+    class Config:
+        # For aliased fields, accept either the canonical name OR the alias
+        populate_by_name = True
+
 
 class ChatbotsMqSubmindDisconnection(MQContext):
-    nick: str = Field(description="User ID of the submind")
+    user_id: str = Field(description="User ID of the submind", alias="nick")
+
+    class Config:
+        # For aliased fields, accept either the canonical name OR the alias
+        populate_by_name = True
 
 
 __all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -131,6 +131,8 @@ class ChatbotsMqResponse(KlatContext, MQContext):
     dom: Any = Field(default=None, deprecated=True)
     omit_reply: Any = Field(default=None, deprecated=True)
     no_save: Any = Field(default=None, deprecated=True)
+    created_on: Any = Field(default=None, deprecated=True)
+    to_discussion: Any = Field(default=None, deprecated=True)
 
     @model_validator(mode='before')
     @classmethod

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -296,7 +296,7 @@ class ConnectedSubmind(BaseModel):
         default=False,
         description="True if the submind will handle all conversation shouts")
     last_ping: datetime = Field(
-        default=lambda: datetime.now(tz=timezone.utc),
+        default_factory=lambda: datetime.now(tz=timezone.utc),
         description="Last time the submind pinged the observer")
 
     bot_type: BotType = Field(

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -185,8 +185,17 @@ class ChatbotsMqSavePrompt(ChatbotsMqResponse):
         description="ID of the CCAI prompt associated with the shout")
     prompt_text: str = Field(default="")
     created_on: str = Field(default="")
-    context: PromptCompletedContext
+    # TODO: patched to resolve errors; consider intended behavior
+    context: Optional[PromptCompletedContext] = Field(default=None)
     
+    @model_validator(mode='before')
+    @classmethod
+    def validate_context(cls, values):
+        # If context is empty, remove it from the values so validation passes
+        if "context" in values and not values["context"]:
+            values.pop("context")
+        return values
+
     def model_dump(self, **kwargs):
         return ChatbotsMqResponse.model_dump(self, **kwargs)
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -146,7 +146,7 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
                           description="If true, this message will be ignored")
     to_discussion: bool = Field(default=False, deprecated=True)
     prompt_state: CcaiState = Field(
-        default=CcaiState.IDLE.value, deprecated=True, alias="promptState",
+        default=CcaiState.IDLE, deprecated=True, alias="promptState",
         description="State of the CCAI conversation associated with the shout")
     
     @model_validator(mode='before')
@@ -192,7 +192,7 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
         by_alias['responded_shout'] = self.replied_message
         by_alias['shout'] = self.message_text
         by_alias['time'] = self.time_created.timestamp()
-        by_alias['promptState'] = self.prompt_state
+        by_alias['promptState'] = self.prompt_state.value
         by_alias['created_on'] = self.time_created.timestamp()
         
         return {**super().model_dump(**kwargs), **by_alias}

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -284,18 +284,23 @@ class ChatbotsMqResponse:
 
 
 class ConnectedSubmind(BaseModel):
-    service_name: str = Field(
-        description="Name of the submind")
+    service_name: Optional[str] = Field(default=None,
+                                        description="Name of the submind")
     attached_cids: List[str] = Field(
+        alias="cids",
         description="List of conversation IDs the submind is participating in")
+    version: Optional[str] = Field(
+        default=None,
+        description="Version of chatbot-core the submind is using")
     supports_raw_conversation: bool = Field(
         default=False,
         description="True if the submind will handle all conversation shouts")
     last_ping: datetime = Field(
+        default = datetime.now(tz=timezone.utc),
         description="Last time the submind pinged the observer")
 
     bot_type: BotType = Field(
-        deprecated=True,
+        deprecated=True, default="submind",
         description="Type of bot (always `submind` in this context)")
 
 class ChatbotsMqSubmindsState(MQContext):
@@ -394,9 +399,9 @@ class ChatbotsMqSubmindConnection(MQContext):
         description="Timestamp when the submind last connected")
     cids: Optional[List[str]] = Field(
         default=None, description="List of conversation IDs the submind is in")
-    supports_raw_conversation: bool = Field(
-        default=False,
-        description="True if the submind supports unprocessed conversations")
+    context: Optional[ConnectedSubmind] = Field(
+        default=None,
+        description="ConnectedSubmind definition of the connecting bot")
 
 
 class ChatbotsMqSubmindDisconnection(MQContext):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -248,6 +248,8 @@ class ChatbotsMqNewPrompt(ChatbotsMqSubmindResponse):
         values.setdefault("context", values.get("conversation_context"))
         if "prompt_text" in values:
             values["messageText"] = values.get("prompt_text")
+        if "nick" in values:
+            values.setdefault("user_id", values.get("nick"))
         return values
     
     def model_dump(self, **kwargs):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -115,8 +115,8 @@ class ChatbotsMqResponse(KlatContext, MQContext):
     prompt_state: Optional[int] = Field(
         default=None, deprecated=True, alias="promptState",
         description="State of the CCAI conversation associated with the shout")
-    is_announcement: Literal["0", "1"] = Field(
-        default='0', alias="isAnnouncement",
+    is_announcement: bool = Field(
+        default=False, alias="isAnnouncement",
         description="`1` if the shout is an announcement")
     time_created: datetime = Field(
         default= datetime.now(tz=timezone.utc), alias="timeCreated",

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -26,7 +26,7 @@
 
 from typing import Literal, Optional, List
 from datetime import datetime, timezone
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from neon_data_models.models.base.contexts import KlatContext, MQContext
 
@@ -126,4 +126,30 @@ class ChatbotResponse(KlatContext, MQContext):
         return super().model_dump(**kwargs)
 
 
-__all__ = [ChatbotRequest.__name__, ChatbotResponse.__name__]
+class ChatbotSavePrompt(ChatbotResponse):
+    prompt_id: str = Field(
+        default="",
+        description="ID of the CCAI prompt associated with the shout")
+    prompt_text: str = Field(default="")
+    created_on: str = Field(default="")
+    
+    def model_dump(self, **kwargs):
+        return ChatbotResponse.model_dump(self, **kwargs)
+
+
+class ChatbotNewPrompt(ChatbotResponse):
+    context: dict
+
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_context(cls, values):
+        values.setdefault("context", values.get("conversation_context"))
+        return values
+    
+    def model_dump(self, **kwargs):
+        return ChatbotResponse.model_dump(self, **kwargs)
+
+
+__all__ = [ChatbotRequest.__name__, ChatbotResponse.__name__,
+           ChatbotSavePrompt.__name__, ChatbotNewPrompt.__name__]

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -24,11 +24,11 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Any, Dict, Literal, Optional, List
+from typing import Any, Dict, Literal, Optional, List, Union, Union
 from datetime import datetime, timezone
-from pydantic import Field, model_validator
+from pydantic import Field, model_validator, TypeAdapter, TypeAdapter
 
-from neon_data_models.enum import SubmindStatus, CcaiState
+from neon_data_models.enum import SubmindStatus, CcaiState, CcaiControl
 from neon_data_models.types import BotType
 from neon_data_models.models.api.llm import LLMPersona
 from neon_data_models.models.base import BaseModel
@@ -91,7 +91,7 @@ class ChatbotsMqRequest(KlatContext, MQContext):
         return data
 
 
-class ChatbotsMqResponse(KlatContext, MQContext):
+class ChatbotsMqSubmindResponse(KlatContext, MQContext):
     """
     Defines a chatbot response to a request.
     """
@@ -115,7 +115,7 @@ class ChatbotsMqResponse(KlatContext, MQContext):
         deprecated=True, alias="conversation_state",
         description="State of the CCAI conversation associated with the shout")
     is_announcement: bool = Field(
-        default=False, alias="isAnnouncement",
+        default=False,
         description="True if the shout is an announcement")
     time_created: datetime = Field(
         default= datetime.now(tz=timezone.utc), alias="timeCreated",
@@ -142,9 +142,15 @@ class ChatbotsMqResponse(KlatContext, MQContext):
             #  keys
             values.setdefault("userID", values.get("nick"))
 
-            values.setdefault("messageText", values.get("shout"))
-            values.setdefault("repliedMessage", values.get("responded_shout"))
-            values.setdefault("timeCreated", values.get("time"))
+            if values.get("shout"):
+                values.setdefault("messageText", values.get("shout"))
+            
+            if values.get("responded_shout"):
+                values.setdefault("repliedMessage",
+                                   values.get("responded_shout"))
+
+            if values.get("time"):
+                values.setdefault("timeCreated", values.get("time"))
 
             if "sid" in values and values["sid"] is None:
                 values.pop("sid")
@@ -165,12 +171,12 @@ class ChatbotsMqResponse(KlatContext, MQContext):
         if 'by_alias' not in kwargs:
             by_alias = super().model_dump(by_alias=True, **kwargs)
 
-            # TODO: Deprecate below serialization patches
-            by_alias['isAnnouncement'] = '1' if self.is_announcement else '0'
-            by_alias['nick'] = self.user_id
-            by_alias['responded_shout'] = self.replied_message
-            by_alias['shout'] = self.message_text
-            by_alias['time'] = self.time_created.timestamp()
+        # TODO: Deprecate below serialization patches
+        by_alias['isAnnouncement'] = '1' if self.is_announcement else '0'
+        by_alias['nick'] = self.user_id
+        by_alias['responded_shout'] = self.replied_message
+        by_alias['shout'] = self.message_text
+        by_alias['time'] = self.time_created.timestamp()
         
         return {**super().model_dump(**kwargs), **by_alias}
 
@@ -189,7 +195,7 @@ class PromptCompletedContext(BaseModel):
     winner: str = ""
 
 
-class ChatbotsMqSavePrompt(ChatbotsMqResponse):
+class ChatbotsMqSavePrompt(ChatbotsMqSubmindResponse):
     prompt_id: str = Field(
         default="",
         description="ID of the CCAI prompt associated with the shout")
@@ -206,10 +212,10 @@ class ChatbotsMqSavePrompt(ChatbotsMqResponse):
         return values
 
     def model_dump(self, **kwargs):
-        return ChatbotsMqResponse.model_dump(self, **kwargs)
+        return ChatbotsMqSubmindResponse.model_dump(self, **kwargs)
 
 
-class ChatbotsMqNewPrompt(ChatbotsMqResponse):
+class ChatbotsMqNewPrompt(ChatbotsMqSubmindResponse):
     prompt_id: str = Field(
         description="ID of the CCAI prompt associated with the shout"
     )
@@ -230,7 +236,29 @@ class ChatbotsMqNewPrompt(ChatbotsMqResponse):
         return values
     
     def model_dump(self, **kwargs):
-        return ChatbotsMqResponse.model_dump(self, **kwargs)
+        return ChatbotsMqSubmindResponse.model_dump(self, **kwargs)
+
+
+class ChatbotsMqResponse:
+    """
+    Type adapter for validating an arbitrary MQ message. This will always return
+    an instance that extends `BaseMessage` and `MQContext`.
+    """
+    @classmethod
+    def __new__(cls, *args, **kwargs) -> Union[ChatbotsMqSavePrompt,
+                                                 ChatbotsMqNewPrompt, 
+                                                 ChatbotsMqSubmindResponse]:
+        message_text = kwargs.get("message_text") or kwargs.get("messageText")
+        
+        if message_text == CcaiControl.SAVE_PROMPT_RESULTS:
+            return ChatbotsMqSavePrompt.model_validate(kwargs)
+        elif message_text == CcaiControl.CREATE_PROMPT:
+            return ChatbotsMqNewPrompt.model_validate(kwargs)
+        else:
+            return ChatbotsMqSubmindResponse.model_validate(kwargs)
+    
+    ta = TypeAdapter(Union[ChatbotsMqSavePrompt, ChatbotsMqNewPrompt, 
+                           ChatbotsMqSubmindResponse])
 
 
 class ConnectedSubmind(MQContext):
@@ -385,15 +413,22 @@ class ChatbotsMqSubmindConversationBan(MQContext):
     user_id: str = Field(description="User ID of the submind", alias="nick")
     cid: str = Field(description="Conversation ID to (un)ban submind from")
 
+    class Config:
+        # For aliased fields, accept either the canonical name OR the alias
+        populate_by_name = True
+
 
 class ChatbotsMqSubmindGlobalBan(MQContext):
     user_id: str = Field(description="User ID of the submind", alias="nick")
 
+    class Config:
+        # For aliased fields, accept either the canonical name OR the alias
+        populate_by_name = True
 
 
 __all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,
-           ChatbotsMqSavePrompt.__name__, ChatbotsMqNewPrompt.__name__,
-           ChatbotsMqSubmindsState.__name__, 
+           ChatbotsMqSubmindResponse.__name__, ChatbotsMqSavePrompt.__name__,
+           ChatbotsMqNewPrompt.__name__, ChatbotsMqSubmindsState.__name__, 
            ChatbotsMqConfiguredPersonasRequest.__name__,
            ChatbotsMqConfiguredPersonasResponse.__name__,
            ChatbotsMqPromptsDataRequest.__name__,

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -32,7 +32,7 @@ from neon_data_models.models.base import BaseModel
 from neon_data_models.models.base.contexts import KlatContext, MQContext
 
 
-class ChatbotRequest(KlatContext, MQContext):
+class ChatbotsMqRequest(KlatContext, MQContext):
     """
     Defines a request from Klat to the Chatbots service.
     """
@@ -60,10 +60,10 @@ class ChatbotRequest(KlatContext, MQContext):
         default=None, description="Service bound to the conversation")
     
     @classmethod
-    def from_sio_message(cls, sio_message: dict) -> 'ChatbotRequest':
+    def from_sio_message(cls, sio_message: dict) -> 'ChatbotsMqRequest':
         klat_context = KlatContext(**sio_message)
         mq_context = MQContext(**sio_message)
-        return ChatbotRequest(
+        return ChatbotsMqRequest(
             **klat_context.model_dump(exclude_none=True),
             **mq_context.model_dump(exclude_none=True),
             username=sio_message.get("userDisplayName") or \
@@ -88,7 +88,10 @@ class ChatbotRequest(KlatContext, MQContext):
         return data
 
 
-class ChatbotResponse(KlatContext, MQContext):
+class ChatbotsMqResponse(KlatContext, MQContext):
+    """
+    Defines a chatbot response to a request.
+    """
     user_id: str = Field(alias='userID', 
                          description="Unique UID of the sender")
     username: Optional[str] = Field(default=None,
@@ -119,16 +122,21 @@ class ChatbotResponse(KlatContext, MQContext):
         default="klat_observer",
         description="Name of the service originating the shout")
     
+    class Config:
+        # For aliased fields, accept either the canonical name OR the alias
+        populate_by_name = True
+
     def model_dump(self, **kwargs):
-        """Override model_dump to use by_alias=True by default"""
-        # Set by_alias=True by default if not specified
+        # For backwards-compat, include aliased keys in serialization
+        by_alias = {}
         if 'by_alias' not in kwargs:
-            kwargs['by_alias'] = True
-        return super().model_dump(**kwargs)
+            by_alias = super().model_dump(by_alias=True, **kwargs)
+        
+        return {**super().model_dump(**kwargs), **by_alias}
 
 
 class PromptCompletedContext(BaseModel):
-    prompt: ChatbotRequest
+    prompt: ChatbotsMqRequest
     is_active: bool
     prompt_text: str
     available_subminds: List[str]
@@ -140,7 +148,7 @@ class PromptCompletedContext(BaseModel):
     votes_per_submind: Dict[str, List[str]]
     winner: str = ""
 
-class ChatbotSavePrompt(ChatbotResponse):
+class ChatbotsMqSavePrompt(ChatbotsMqResponse):
     prompt_id: str = Field(
         default="",
         description="ID of the CCAI prompt associated with the shout")
@@ -149,17 +157,21 @@ class ChatbotSavePrompt(ChatbotResponse):
     context: PromptCompletedContext
     
     def model_dump(self, **kwargs):
-        return ChatbotResponse.model_dump(self, **kwargs)
+        return ChatbotsMqResponse.model_dump(self, **kwargs)
 
 
-class ChatbotNewPrompt(ChatbotResponse):
+class ChatbotsMqNewPrompt(ChatbotsMqResponse):
     prompt_id: str = Field(
         description="ID of the CCAI prompt associated with the shout"
     )
     user_id: Optional[str] = Field(default=None)
     prompt_text: str = Field(default="")
-    context: Optional[dict] = Field(default=None)
+    context: Optional[dict] = Field(default=None,
+                                    alias="conversation_context")
 
+    class Config:
+        # For aliased fields, accept either the canonical name OR the alias
+        populate_by_name = True
 
     @model_validator(mode='before')
     @classmethod
@@ -169,8 +181,8 @@ class ChatbotNewPrompt(ChatbotResponse):
         return values
     
     def model_dump(self, **kwargs):
-        return ChatbotResponse.model_dump(self, **kwargs)
+        return ChatbotsMqResponse.model_dump(self, **kwargs)
 
 
-__all__ = [ChatbotRequest.__name__, ChatbotResponse.__name__,
-           ChatbotSavePrompt.__name__, ChatbotNewPrompt.__name__]
+__all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,
+           ChatbotsMqSavePrompt.__name__, ChatbotsMqNewPrompt.__name__]

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -114,8 +114,7 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
         default=None, alias="promptID",
         description="ID of the CCAI prompt associated with the shout")
     prompt_state: CcaiState = Field(
-        default=CcaiState.IDLE,  # Default for backwards-compat. with cb-observer
-        deprecated=True, alias="conversation_state",
+        deprecated=True, alias="promptState",
         description="State of the CCAI conversation associated with the shout")
     is_announcement: bool = Field(
         default=False, alias="isAnnouncement",
@@ -126,11 +125,8 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
     source: str = Field(
         default="klat_observer",
         description="Name of the service originating the shout")
-    bot_type: BotType = Field(default=None, deprecated=True,
+    bot_type: Optional[BotType] = Field(default=None, deprecated=True,
                               description="Type of submind sending the shout")
-    participating_subminds: Optional[List[str]] = Field(
-        default=[], deprecated=True,
-        description="List of subminds participating in the shout")
     # service_name: Any = Field(default=None, deprecated=True)
     # context: Optional[dict] = Field(
     #     default=None, deprecated=True,
@@ -169,6 +165,10 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
 
             if "sid" in values and values["sid"] is None:
                 values.pop("sid")
+
+            if "conversation_state" in values:
+                values.setdefault("promptState",
+                                  values.get("conversation_state"))
 
             # # TODO: Mark as deprecated
             # if values.get('bot_type') in ('proctor', 'observer'):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -235,6 +235,9 @@ class ChatbotsMqNewPrompt(ChatbotsMqSubmindResponse):
     user_id: Optional[str] = Field(default=None, alias="nick",
                                    description="User ID of the proctor")
     prompt_text: str = Field(description="The new prompt being discussed")
+    prompt_state: CcaiState = Field(
+        default=CcaiState.IDLE, deprecated=True,
+        description="Implemented for backwards-compat. New Prompt always IDLE")
     context: Optional[dict] = Field(default=None, deprecated=True,
                                     alias="conversation_context")
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -120,9 +120,6 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
     prompt_id: Optional[str] = Field(
         default=None, alias="promptID",
         description="ID of the CCAI prompt associated with the shout")
-    prompt_state: CcaiState = Field(
-        deprecated=True, alias="promptState",
-        description="State of the CCAI conversation associated with the shout")
     is_announcement: bool = Field(
         default=False, alias="isAnnouncement",
         description="True if the shout is an announcement")
@@ -148,7 +145,10 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
     no_save: bool = Field(default=False, deprecated=True,
                           description="If true, this message will be ignored")
     to_discussion: bool = Field(default=False, deprecated=True)
-
+    prompt_state: CcaiState = Field(
+        default=CcaiState.IDLE, deprecated=True, alias="promptState",
+        description="State of the CCAI conversation associated with the shout")
+    
     @model_validator(mode='before')
     @classmethod
     def validate_inputs(cls, values):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -111,8 +111,8 @@ class ChatbotsMqResponse(KlatContext, MQContext):
     prompt_id: Optional[str] = Field(
         default=None, alias="promptID",
         description="ID of the CCAI prompt associated with the shout")
-    prompt_state: Optional[int] = Field(
-        default=None, deprecated=True, alias="promptState",
+    prompt_state: int = Field(
+        deprecated=True, alias="conversation_state",
         description="State of the CCAI conversation associated with the shout")
     is_announcement: bool = Field(
         default=False, alias="isAnnouncement",
@@ -126,11 +126,10 @@ class ChatbotsMqResponse(KlatContext, MQContext):
     
     bot_type: BotType = Field(default=None, deprecated=True)
     service_name: Any = Field(default=None, deprecated=True)
-    conversation_state: Any = Field(default=None, deprecated=True)
-    context: dict = Field(default=None, deprecated=True)
+    context: Optional[dict] = Field(default=None)  # TODO Maybe deprecate as responses that need it specify this param separately
     dom: Any = Field(default=None, deprecated=True)
-    omit_reply: Any = Field(default=None, deprecated=True)
-    no_save: Any = Field(default=None, deprecated=True)
+    omit_reply: bool = Field(default=True, deprecated=True)
+    no_save: bool = Field(default=False, deprecated=True)
     created_on: Any = Field(default=None, deprecated=True)
     to_discussion: Any = Field(default=None, deprecated=True)
 
@@ -196,8 +195,7 @@ class ChatbotsMqSavePrompt(ChatbotsMqResponse):
         description="ID of the CCAI prompt associated with the shout")
     prompt_text: str = Field(default="")
     created_on: str = Field(default="")
-    # TODO: patched to resolve errors; consider intended behavior
-    context: Optional[PromptCompletedContext] = Field(default=None)
+    context: PromptCompletedContext = Field()
     
     @model_validator(mode='before')
     @classmethod

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -102,8 +102,7 @@ class ChatbotsMqResponse(KlatContext, MQContext):
                                     description="Username of the sender")
     message_text: str = Field(alias="messageText",
                               description="Text content of the shout")
-    sid: Optional[str] = Field(default=None, alias="messageID",
-                               description="Shout ID")
+    sid: str = Field(default="", alias="messageID", description="Shout ID")
     replied_message: Optional[str] = Field(
         default=None, alias="repliedMessage",
         description="ID of the shout being replied to")
@@ -144,6 +143,9 @@ class ChatbotsMqResponse(KlatContext, MQContext):
             values.setdefault("messageText", values.get("shout"))
             values.setdefault("repliedMessage", values.get("responded_shout"))
             values.setdefault("timeCreated", values.get("time"))
+
+            if "sid" in values and values["sid"] is None:
+                values.pop("sid")
 
             # TODO: Mark as deprecated
             if values.get('bot_type') in ('proctor', 'observer'):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -285,9 +285,9 @@ class ChatbotsMqResponse:
 
 class ConnectedSubmind(BaseModel):
     service_name: Optional[str] = Field(default=None,
-                                        description="Name of the submind")
+                                        description="Unique ID of the submind")
     attached_cids: List[str] = Field(
-        alias="cids",
+        default = [], alias="cids",
         description="List of conversation IDs the submind is participating in")
     version: Optional[str] = Field(
         default=None,

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -380,6 +380,17 @@ class ChatbotsMqUpdateParticipatingSubminds(MQContext):
         default=[],
         description="List of submind User IDs to evict from the conversation")
 
+
+class ChatbotsMqSubmindConversationBan(MQContext):
+    user_id: str = Field(description="User ID of the submind", alias="nick")
+    cid: str = Field(description="Conversation ID to (un)ban submind from")
+
+
+class ChatbotsMqSubmindGlobalBan(MQContext):
+    user_id: str = Field(description="User ID of the submind", alias="nick")
+
+
+
 __all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,
            ChatbotsMqSavePrompt.__name__, ChatbotsMqNewPrompt.__name__,
            ChatbotsMqSubmindsState.__name__, 
@@ -390,4 +401,6 @@ __all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,
            ChatbotsMqSubmindConnection.__name__,
            ChatbotsMqSubmindDisconnection.__name__,
            ChatbotsMqSubmindInvitation.__name__,
-           ChatbotsMqUpdateParticipatingSubminds.__name__,]
+           ChatbotsMqUpdateParticipatingSubminds.__name__,
+           ChatbotsMqSubmindConversationBan.__name__,
+           ChatbotsMqSubmindGlobalBan.__name__,]

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -30,6 +30,7 @@ from pydantic import Field, model_validator
 
 from neon_data_models.enum import SubmindStatus, CcaiState
 from neon_data_models.types import BotType
+from neon_data_models.models.api.llm import LLMPersona
 from neon_data_models.models.base import BaseModel
 from neon_data_models.models.base.contexts import KlatContext, MQContext
 
@@ -150,6 +151,7 @@ class PromptCompletedContext(BaseModel):
     votes_per_submind: Dict[str, List[str]]
     winner: str = ""
 
+
 class ChatbotsMqSavePrompt(ChatbotsMqResponse):
     prompt_id: str = Field(
         default="",
@@ -226,6 +228,52 @@ class ChatbotsMqSubmindsState(MQContext):
         description="List of globally banned submind `user_id`s")
 
 
+class ChatbotsMqConfiguredPersonasRequest(MQContext):
+    service_name: str = Field(
+        description="Name of the service to get personas for")
+
+
+class ChatbotsMqConfiguredPersonasResponse(MQContext):
+    update_time: datetime = Field(
+        description="Time the personas were last checked")
+    items: List[LLMPersona]
+    context: dict = Field(deprecated=True)
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_context(cls, values):
+        # Deprecated context handling for backwards-compat.
+        if 'context' not in values and 'message_id' in values:
+            values['context'] = {"mq": {"message_id": values['message_id']}}
+        return values
+        
+    def model_dump(self, **kwargs):
+        """
+        Override model_dump to include 'persona_name' field for each item based 
+        on its 'name' for backwards-compat.
+        """
+        data = super().model_dump(**kwargs)
+        for item in data['items']:
+            item['persona_name'] = item['name']
+        return data
+
+    @classmethod
+    def from_persona_response(cls, data: dict, service_name: str):
+        data["items"] = [item for item in data["items"]
+                         if service_name in item["supported_llms"]]
+        return cls(**data)
+
+
+class ChatbotsMqPromptsDataRequest(MQContext):
+    pass
+
+
+class ChatbotsMqPromptsDataResponse(MQContext):
+    pass
+
+
 __all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,
            ChatbotsMqSavePrompt.__name__, ChatbotsMqNewPrompt.__name__,
-           ChatbotsMqSubmindsState.__name__]
+           ChatbotsMqSubmindsState.__name__, 
+           ChatbotsMqConfiguredPersonasRequest.__name__,
+           ChatbotsMqConfiguredPersonasResponse.__name__]

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -24,10 +24,11 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Literal, Optional, List
+from typing import Dict, Literal, Optional, List
 from datetime import datetime, timezone
 from pydantic import Field, model_validator
 
+from neon_data_models.models.base import BaseModel
 from neon_data_models.models.base.contexts import KlatContext, MQContext
 
 
@@ -126,12 +127,17 @@ class ChatbotResponse(KlatContext, MQContext):
         return super().model_dump(**kwargs)
 
 
+class PromptCompletedContext(BaseModel):
+    prompt: Dict[str, str]
+    winner: str = ""
+
 class ChatbotSavePrompt(ChatbotResponse):
     prompt_id: str = Field(
         default="",
         description="ID of the CCAI prompt associated with the shout")
     prompt_text: str = Field(default="")
     created_on: str = Field(default="")
+    context: PromptCompletedContext
     
     def model_dump(self, **kwargs):
         return ChatbotResponse.model_dump(self, **kwargs)
@@ -140,7 +146,7 @@ class ChatbotSavePrompt(ChatbotResponse):
 class ChatbotNewPrompt(ChatbotResponse):
     user_id: Optional[str] = Field(default=None)
     prompt_text: str = Field(default="")
-    context: Optional[dict] = None
+    context: Optional[dict] = Field(default=None)
 
 
     @model_validator(mode='before')

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -245,14 +245,14 @@ class ChatbotsMqResponse:
     an instance that extends `BaseMessage` and `MQContext`.
     """
     @classmethod
-    def __new__(cls, *args, **kwargs) -> Union[ChatbotsMqSavePrompt,
-                                                 ChatbotsMqNewPrompt, 
-                                                 ChatbotsMqSubmindResponse]:
+    def __new__(cls, *_, **kwargs) -> Union[ChatbotsMqSavePrompt,
+                                            ChatbotsMqNewPrompt, 
+                                            ChatbotsMqSubmindResponse]:
         message_text = kwargs.get("message_text") or kwargs.get("messageText")
         
-        if message_text == CcaiControl.SAVE_PROMPT_RESULTS:
+        if message_text == CcaiControl.SAVE_PROMPT_RESULTS.value:
             return ChatbotsMqSavePrompt.model_validate(kwargs)
-        elif message_text == CcaiControl.CREATE_PROMPT:
+        elif message_text == CcaiControl.CREATE_PROMPT.value:
             return ChatbotsMqNewPrompt.model_validate(kwargs)
         else:
             return ChatbotsMqSubmindResponse.model_validate(kwargs)

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -147,9 +147,9 @@ class ChatbotsMqResponse(KlatContext, MQContext):
             if "sid" in values and values["sid"] is None:
                 values.pop("sid")
 
-            # TODO: Mark as deprecated
-            if values.get('bot_type') in ('proctor', 'observer'):
-                values['bot_type'] = 'facilitator'
+            # # TODO: Mark as deprecated
+            # if values.get('bot_type') in ('proctor', 'observer'):
+            #     values['bot_type'] = 'facilitator'
 
         return values
 
@@ -246,8 +246,8 @@ class ConnectedSubmind(MQContext):
     @classmethod
     def validate_context(cls, values):
         # TODO: Mark as deprecated
-        if values.get('bot_type') in ('proctor', 'observer'):
-            values['bot_type'] = 'facilitator'
+        # if values.get('bot_type') in ('proctor', 'observer'):
+        #     values['bot_type'] = 'facilitator'
         if values.get('shout') == 'hello':
             values['shout'] = 'chatbot state'
         return values

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -1,0 +1,85 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2025 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Optional, List
+from datetime import datetime
+from pydantic import Field
+
+from neon_data_models.models.base.contexts import KlatContext, MQContext
+
+
+class ChatbotRequest(KlatContext, MQContext):
+    """
+    Defines a request from Klat to the Chatbots service.
+    """
+    username: str = Field(description="Username of the sender")
+    cid: str = Field(description="Conversation ID associated with the shout")
+    message_text: str = Field(description="Text content of the shout")
+    from_bot: bool = Field(
+        default=False,
+        description="True if the shout is from a bot, False if from a user")
+    prompt_id: Optional[str] = Field(
+        default=None,
+        description="ID of the CCAI prompt associated with the shout")
+    prompt_state: Optional[int] = Field(
+        default=None, deprecated=True,
+        description="State of the CCAI conversation associated with the shout")
+    time_created: datetime = Field(
+        description="Timestamp when the shout was created")
+    requested_participants: Optional[List[str]] = Field(
+        default=None, 
+        description="List of CCAI participants requested to handle the shout")
+    recipient: Optional[str] = Field(
+        default=None, description="Explicitly defined recipient of the shout. ")
+    bound_service: Optional[str] = Field(
+        default=None, description="Service bound to the conversation")
+    
+    @classmethod
+    def from_sio_message(cls, sio_message: dict) -> 'ChatbotRequest':
+        klat_context = KlatContext(**sio_message)
+        mq_context = MQContext(**sio_message)
+        return ChatbotRequest(
+            **klat_context.model_dump(exclude_none=True),
+            **mq_context.model_dump(exclude_none=True),
+            username=sio_message["userDisplayName"],
+            message_text=sio_message["messageText"],
+            from_bot=sio_message.get("bot") == 1,
+            prompt_id = sio_message.get("promptId"),
+            prompt_state=sio_message.get("promptState"),
+            time_created=sio_message["timeCreated"],
+            recipient=sio_message.get("recipient"),
+            bound_service=sio_message.get("bound_service"),
+        )
+    
+    def model_dump(self, **kwargs):
+        """Override model_dump to include 'bot' field for backwards compatibility"""
+        data = super().model_dump(**kwargs)
+        # Add the 'bot' parameter as '1' or '0' string for backwards compatibility
+        data["bot"] = "1" if self.from_bot else "0"
+        return data
+
+
+__all__ = [ChatbotRequest.__name__]

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -115,7 +115,7 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
         deprecated=True, alias="conversation_state",
         description="State of the CCAI conversation associated with the shout")
     is_announcement: bool = Field(
-        default=False,
+        default=False, alias="isAnnouncement",
         description="True if the shout is an announcement")
     time_created: datetime = Field(
         default= datetime.now(tz=timezone.utc), alias="timeCreated",
@@ -172,7 +172,7 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
         if 'by_alias' not in kwargs:
             by_alias = super().model_dump(by_alias=True, **kwargs)
 
-        # TODO: Deprecate below serialization patches
+        # TODO: Below are for SIO compat.
         by_alias['isAnnouncement'] = '1' if self.is_announcement else '0'
         by_alias['nick'] = self.user_id
         by_alias['responded_shout'] = self.replied_message
@@ -201,7 +201,7 @@ class ChatbotsMqSavePrompt(ChatbotsMqSubmindResponse):
         default="",
         description="ID of the CCAI prompt associated with the shout")
     prompt_text: str = Field(default="")
-    created_on: Optional[str] = Field(default=None)
+    created_on: str = Field(default="")
     context: PromptCompletedContext = Field(alias="conversation_context")
 
     @model_validator(mode='before')
@@ -212,6 +212,14 @@ class ChatbotsMqSavePrompt(ChatbotsMqSubmindResponse):
             values.pop("context")
         return values
 
+    @model_validator(mode='before')
+    @classmethod
+    def validate_context(cls, values):
+        # TODO: Patching invalid input for backwards-compat.
+        if "created_on" in values and values["created_on"] is None:
+            values.pop("created_on")
+        return values
+    
     def model_dump(self, **kwargs):
         return ChatbotsMqSubmindResponse.model_dump(self, **kwargs)
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -114,6 +114,7 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
         default=None, alias="promptID",
         description="ID of the CCAI prompt associated with the shout")
     prompt_state: int = Field(
+        default=CcaiState.IDLE.value,  # Default for backwards-compat. with cb-observer
         deprecated=True, alias="conversation_state",
         description="State of the CCAI conversation associated with the shout")
     is_announcement: bool = Field(
@@ -233,11 +234,10 @@ class ChatbotsMqNewPrompt(ChatbotsMqSubmindResponse):
     context: Optional[dict] = Field(default=None, deprecated=True,
                                     alias="conversation_context")
 
-
     @model_validator(mode='before')
     @classmethod
     def validate_context(cls, values):
-        values.setdefault("message_text", values.get("shout"))
+        values.setdefault("message_text", values.get("shout", ""))
         values.setdefault("user_id", values.get("nick"))
         return values
     
@@ -277,6 +277,7 @@ class ConnectedSubmind(BaseModel):
     attached_cids: List[str] = Field(
         description="List of conversation IDs the submind is participating in")
     supports_raw_shouts: bool = Field(
+        default=False,
         description="True if the submind will handle all conversation shouts")  # TODO: Refactor?
     last_ping: datetime = Field(
         description="Last time the submind pinged the observer")

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -31,6 +31,7 @@ from pydantic import Field, model_validator
 from neon_data_models.enum import SubmindStatus, CcaiState, CcaiControl
 from neon_data_models.types import BotType
 from neon_data_models.models.api.llm import LLMPersona
+from neon_data_models.models.api.chatbots import ConnectedSubmind
 from neon_data_models.models.base import BaseModel
 from neon_data_models.models.base.contexts import KlatContext, MQContext
 
@@ -283,25 +284,7 @@ class ChatbotsMqResponse:
             return ChatbotsMqSubmindResponse(**kwargs)
 
 
-class ConnectedSubmind(BaseModel):
-    service_name: Optional[str] = Field(default=None,
-                                        description="Unique ID of the submind")
-    attached_cids: List[str] = Field(
-        default=[], alias="cids",
-        description="List of conversation IDs the submind is participating in")
-    version: Optional[str] = Field(
-        default=None,
-        description="Version of chatbot-core the submind is using")
-    supports_raw_conversation: bool = Field(
-        default=False,
-        description="True if the submind will handle all conversation shouts")
-    last_ping: datetime = Field(
-        default_factory=lambda: datetime.now(tz=timezone.utc),
-        description="Last time the submind pinged the observer")
 
-    bot_type: BotType = Field(
-        deprecated=True, default="submind",
-        description="Type of bot (always `submind` in this context)")
 
 class ChatbotsMqSubmindsState(MQContext):
     class SubmindState(BaseModel):
@@ -402,6 +385,15 @@ class ChatbotsMqSubmindConnection(MQContext):
     context: Optional[ConnectedSubmind] = Field(
         default=None,
         description="ConnectedSubmind definition of the connecting bot")
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_context(cls, values):
+        if "context" in values:
+            values["context"].setdefault("service_name",
+                                          values.get("user_id").rsplit('-',
+                                                                        1)[0])
+            return values
 
 
 class ChatbotsMqSubmindDisconnection(MQContext):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -24,9 +24,9 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Any, Dict, Literal, Optional, List, Union, Union
+from typing import Any, Dict, Literal, Optional, List, Union
 from datetime import datetime, timezone
-from pydantic import Field, model_validator, TypeAdapter, TypeAdapter
+from pydantic import Field, model_validator
 
 from neon_data_models.enum import SubmindStatus, CcaiState, CcaiControl
 from neon_data_models.types import BotType
@@ -124,14 +124,19 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
         default="klat_observer",
         description="Name of the service originating the shout")
     
-    bot_type: BotType = Field(default=None, deprecated=True)
-    service_name: Any = Field(default=None, deprecated=True)
-    context: Optional[dict] = Field(default=None)  # TODO Maybe deprecate as responses that need it specify this param separately
-    dom: Any = Field(default=None, deprecated=True)
-    omit_reply: bool = Field(default=True, deprecated=True)
-    no_save: bool = Field(default=False, deprecated=True)
-    created_on: Any = Field(default=None, deprecated=True)
-    to_discussion: Any = Field(default=None, deprecated=True)
+    bot_type: BotType = Field(default=None, deprecated=True,
+                              description="Type of submind sending the shout")
+    # service_name: Any = Field(default=None, deprecated=True)
+    # context: Optional[dict] = Field(default=None, deprecated=True)
+    # dom: Any = Field(default=None, deprecated=True,
+    #                  description="Domain of this conversation")
+    # omit_reply: bool = Field(
+    #     default=True, deprecated=True,
+    #     description="If true, the Proctor will ignore this message")
+    # no_save: bool = Field(default=False, deprecated=True)
+    created_on: datetime = Field(default=datetime.now(timezone.utc),
+                                 description="Timestamp of response")
+    # to_discussion: bool = Field(default=False, deprecated=True)
 
     @model_validator(mode='before')
     @classmethod
@@ -202,24 +207,21 @@ class ChatbotsMqSavePrompt(ChatbotsMqSubmindResponse):
         default="",
         description="ID of the CCAI prompt associated with the shout")
     prompt_text: str = Field(default="")
-    created_on: str = Field(default="")
+    # created_on: str = Field(default="", deprecated=True,
+    #                         description="String date of prompt creation.")
     context: PromptCompletedContext = Field(alias="conversation_context")
 
-    @model_validator(mode='before')
-    @classmethod
-    def validate_context(cls, values):
-        if "context" in values and not values["context"]:
-            # Pop to replace with `conversation_context` or fail
-            values.pop("context")
-        return values
+    # @model_validator(mode='before')
+    # @classmethod
+    # def validate_context(cls, values):
+    #     # if "context" in values and not values["context"]:
+    #     #     # Pop to replace with `conversation_context` or fail
+    #     #     values.pop("context")
 
-    @model_validator(mode='before')
-    @classmethod
-    def validate_context(cls, values):
-        # TODO: Patching invalid input for backwards-compat.
-        if "created_on" in values and values["created_on"] is None:
-            values.pop("created_on")
-        return values
+    #     # TODO: Patching invalid input for backwards-compat.
+    #     if "created_on" in values and values["created_on"] is None:
+    #         values.pop("created_on")
+    #     return values
     
     def model_dump(self, **kwargs):
         return ChatbotsMqSubmindResponse.model_dump(self, **kwargs)
@@ -275,8 +277,8 @@ class ChatbotsMqResponse:
         else:
             return ChatbotsMqSubmindResponse(**kwargs)
     
-    ta = TypeAdapter(Union[ChatbotsMqSavePrompt, ChatbotsMqNewPrompt, 
-                           ChatbotsMqSubmindResponse])
+    # ta = TypeAdapter(Union[ChatbotsMqSavePrompt, ChatbotsMqNewPrompt, 
+    #                        ChatbotsMqSubmindResponse])
 
 
 class ConnectedSubmind(MQContext):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -39,9 +39,11 @@ class ChatbotsMqRequest(KlatContext, MQContext):
     """
     Defines a request from Klat to the Chatbots service.
     """
-    username: str = Field(description="Username (or 'nick') of the sender")
+    username: str = Field(alias="nick",
+                          description="Username (or 'nick') of the sender")
     cid: str = Field(description="Conversation ID associated with the shout")
-    message_text: str = Field(description="Text content of the shout")
+    message_text: str = Field(alias="messageText",
+                              description="Text content of the shout")
     from_bot: bool = Field(
         default=False,
         description="True if the shout is from a bot, False if from a user")
@@ -88,8 +90,6 @@ class ChatbotsMqRequest(KlatContext, MQContext):
         
         # Add parameters for backwards-compat.
         data["bot"] = "1" if self.from_bot else "0"
-        data["messageText"] = self.message_text
-        data["nick"] = self.username
         return data
 
 
@@ -127,33 +127,33 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
         description="Name of the service originating the shout")
     bot_type: Optional[BotType] = Field(default=None, deprecated=True,
                               description="Type of submind sending the shout")
-    # service_name: Any = Field(default=None, deprecated=True)
-    # context: Optional[dict] = Field(
-    #     default=None, deprecated=True,
-    #     description="Context used for Klat Server backwards-compat.")
-    # dom: Any = Field(default=None, deprecated=True,
-    #                  description="Domain of this conversation")
-    # omit_reply: bool = Field(
-    #     default=True, deprecated=True,
-    #     description="If true, the Proctor will ignore this message")
-    # no_save: bool = Field(default=False, deprecated=True,
-    #                       description="If true, this message will be ignored")
-    # to_discussion: bool = Field(default=False, deprecated=True)
+    
+    # Below are deprecated fields for backwards-compat.
+    service_name: Any = Field(default=None, deprecated=True)
+    context: Optional[dict] = Field(
+        default=None, deprecated=True,
+        description="Context used for Klat Server backwards-compat.")
+    dom: Any = Field(default=None, deprecated=True,
+                     description="Domain of this conversation")
+    omit_reply: bool = Field(
+        default=True, deprecated=True,
+        description="If true, the Proctor will ignore this message")
+    no_save: bool = Field(default=False, deprecated=True,
+                          description="If true, this message will be ignored")
+    to_discussion: bool = Field(default=False, deprecated=True)
 
     @model_validator(mode='before')
     @classmethod
     def validate_inputs(cls, values):
         if isinstance(values, dict):
-            # Some references use different keys
-            # TODO: prevent `None` values from being added here in place of missing
-            #  keys
+            # Some additional aliases for backwards-compat.
             if "nick" in values:
                 values.setdefault("userID", values.get("nick"))
 
             if "shout" in values:
                 values.setdefault("messageText", values.get("shout"))
             
-            if values.get("responded_shout"):
+            if "responded_shout" in values:
                 values.setdefault("repliedMessage",
                                    values.get("responded_shout"))
 
@@ -170,19 +170,16 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
                 values.setdefault("promptState",
                                   values.get("conversation_state"))
 
-            # # TODO: Mark as deprecated
-            # if values.get('bot_type') in ('proctor', 'observer'):
-            #     values['bot_type'] = 'facilitator'
-
         return values
 
     def model_dump(self, **kwargs):
-        # For backwards-compat, include aliased keys in serialization
+        # For backwards-compat with Klat Server, include aliased keys in 
+        # serialization. In the future, this should be configurable and
+        # eventually removed.
         by_alias = {}
         if 'by_alias' not in kwargs:
             by_alias = super().model_dump(by_alias=True, **kwargs)
 
-        # TODO: Below are for SIO compat.
         by_alias['isAnnouncement'] = '1' if self.is_announcement else '0'
         by_alias['nick'] = self.user_id
         by_alias['responded_shout'] = self.replied_message
@@ -197,12 +194,10 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
 class PromptCompletedContext(BaseModel):
     prompt: Optional[ChatbotsMqRequest] = Field(
         default=None, description="Original request containing the prompt")
-    is_active: bool = Field(
-        default=False, description="True if a response has not yet been chosen")
+
     prompt_text: str = Field(description="The string prompt that is completed")
-    available_subminds: List[str] = Field(
+    available_subminds: List[str] = Field(  # Seems to always match `participating_subminds`
         default=[], description="List of subminds available to participate")
-    state: Optional[int] = Field(default=None)  # TODO: Define
     participating_subminds: List[str] = Field(
         default=[], description="List of subminds participating in the prompt")
     proposed_responses: Dict[str, str] = Field(
@@ -217,6 +212,14 @@ class PromptCompletedContext(BaseModel):
     votes_per_submind: Dict[str, List[str]] = Field(
         default={}, description="Dict of nick to list of received votes")
     winner: str = Field(default="", description="Selected winner")
+
+    # Below are deprecated
+    is_active: bool = Field(  # Seems to report active all the time
+        default=False, deprecated=True
+        description="True if a response has not yet been chosen")
+    state: Optional[CcaiState] = Field(
+        default=CcaiState.PICK, deprecated=True,
+        description="State of the CCAI conversation (always PICK)")
 
 
 class ChatbotsMqSavePrompt(ChatbotsMqSubmindResponse):
@@ -271,24 +274,22 @@ class ChatbotsMqResponse:
             return ChatbotsMqNewPrompt(**kwargs)
         else:
             return ChatbotsMqSubmindResponse(**kwargs)
-    
-    # ta = TypeAdapter(Union[ChatbotsMqSavePrompt, ChatbotsMqNewPrompt, 
-    #                        ChatbotsMqSubmindResponse])
 
 
 class ConnectedSubmind(BaseModel):
-    bot_type: BotType = Field(
-        description="Type of bot (e.g. facilitator, submind)")  # TODO: Always `submind`?
     service_name: str = Field(
         description="Name of the submind")
     attached_cids: List[str] = Field(
         description="List of conversation IDs the submind is participating in")
-    supports_raw_shouts: bool = Field(
+    supports_raw_conversation: bool = Field(
         default=False,
-        description="True if the submind will handle all conversation shouts")  # TODO: Refactor?
+        description="True if the submind will handle all conversation shouts")
     last_ping: datetime = Field(
         description="Last time the submind pinged the observer")
 
+    bot_type: BotType = Field(
+        deprecated=True,
+        description="Type of bot (always `submind` in this context)")
 
 class ChatbotsMqSubmindsState(MQContext):
     class SubmindState(BaseModel):
@@ -296,8 +297,6 @@ class ChatbotsMqSubmindsState(MQContext):
         status: SubmindStatus = Field(
             description="Subminds's status in a particular conversation")
 
-    msg_type: Literal["subminds_state"] = Field(
-        "subminds_state", description="Message type for SIO", deprecated=True)
     subminds_per_cid: Dict[str, List[SubmindState]] = Field(
         description="List of submind participants per conversation ID")
     connected_subminds: Dict[str, ConnectedSubmind] = Field(
@@ -306,6 +305,9 @@ class ChatbotsMqSubmindsState(MQContext):
         description="Dict of `cid` to list of banned submind `user_id`s")
     banned_subminds: List[str] = Field(
         description="List of globally banned submind `user_id`s")
+
+    msg_type: Literal["subminds_state"] = Field(
+        "subminds_state", description="Message type for SIO", deprecated=True)
 
 
 class ChatbotsMqConfiguredPersonasRequest(MQContext):
@@ -320,6 +322,7 @@ class ChatbotsMqConfiguredPersonasResponse(MQContext):
         description="Time the personas were last checked")
     items: List[LLMPersona] = Field(
         description="List of configured personas from Klat")
+
     context: dict = Field(deprecated=True)
 
     @model_validator(mode='before')
@@ -335,10 +338,12 @@ class ChatbotsMqConfiguredPersonasResponse(MQContext):
         Override model_dump to include 'persona_name' field for each item based 
         on its 'name' for backwards-compat. with Klat server
         """
-        data = super().model_dump(**kwargs)
-        for item in data['items']:
-            item['persona_name'] = item['name']
-        return data
+        by_alias = {}
+        if 'by_alias' not in kwargs:
+            # `by_alias` to include `persona_name` in serialized `LLMPersona`s
+            by_alias = super().model_dump(by_alias=True, **kwargs)
+        
+        return {**super().model_dump(**kwargs), **by_alias}
 
     @classmethod
     def from_persona_request(cls, data: dict,
@@ -357,6 +362,7 @@ class ChatbotsMqPromptsDataRequest(MQContext):
 
 class ChatbotsMqPromptsDataResponse(MQContext):
     records: List[str] = Field(description="List of configured prompts")
+
     context: dict = Field(deprecated=True)
 
     @model_validator(mode='before')
@@ -381,9 +387,9 @@ class ChatbotsMqSubmindConnection(MQContext):
         description="Timestamp when the submind last connected")
     cids: Optional[List[str]] = Field(
         default=None, description="List of conversation IDs the submind is in")
-    supports_raw_shouts: bool = Field(
+    supports_raw_conversation: bool = Field(
         default=False,
-          description="True if the submind supports unprocessed conversations")
+        description="True if the submind supports unprocessed conversations")
 
 
 class ChatbotsMqSubmindDisconnection(MQContext):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -390,9 +390,9 @@ class ChatbotsMqSubmindConnection(MQContext):
     @classmethod
     def validate_context(cls, values):
         if "context" in values and isinstance(values["context"], dict):
+            user_id = values.get("user_id") or values.get("nick") or ""
             values["context"].setdefault("service_name",
-                                          values.get("user_id").rsplit('-',
-                                                                        1)[0])
+                                          user_id.rsplit('-',1)[0])
         return values
 
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -147,8 +147,6 @@ class ChatbotsMqResponse(KlatContext, MQContext):
         # TODO: Mark as deprecated
         if values.get('bot_type') in ('proctor', 'observer'):
             values['bot_type'] = 'facilitator'
-        if values.get('shout') == 'hello':
-            values['shout'] = 'chatbot state'
 
         return values
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -24,10 +24,12 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Dict, Literal, Optional, List
+from typing import Any, Dict, Literal, Optional, List
 from datetime import datetime, timezone
 from pydantic import Field, model_validator
 
+from neon_data_models.enum import SubmindStatus, CcaiState
+from neon_data_models.types import BotType
 from neon_data_models.models.base import BaseModel
 from neon_data_models.models.base.contexts import KlatContext, MQContext
 
@@ -184,5 +186,36 @@ class ChatbotsMqNewPrompt(ChatbotsMqResponse):
         return ChatbotsMqResponse.model_dump(self, **kwargs)
 
 
+class ConnectedSubmind(MQContext):
+    bot_type: BotType
+    service_name: str
+    cid: str = Field(deprecated=True)
+    dom: str = Field(deprecated=True)
+    conversation_state: CcaiState
+    responded_shout: Optional[str] = Field(deprecated=True)
+    shout: Literal["chatbot state"] = Field(deprecated=True)
+    context: Dict[str, Any]  # TODO: Refactor?
+    prompt_id: Optional[str] = Field(deprecated=True)
+    omit_reply: bool = Field(deprecated=True)
+    no_save: bool = Field(deprecated=True)
+    attached_cids: List[str]
+    supports_raw_shouts: bool  # TODO: Refactor?
+    last_ping: datetime
+
+
+class ChatbotsMqSubmindsState(MQContext):
+    class SubmindState(BaseModel):
+        submind_id: str = Field(description="Connected submind's user_id")
+        status: SubmindStatus = Field(
+            description="Subminds's status in a particular conversation")
+    subminds_per_cid: Dict[str, List[SubmindState]]
+    connected_subminds: Dict[str, ConnectedSubmind]
+    cid_submind_bans: Dict[str, List[str]] = Field(
+        description="List of banned submind `user_id`s per `cid`")
+    banned_subminds: List[str] = Field(
+        description="List of globally banned submind `user_id`s")
+
+
 __all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,
-           ChatbotsMqSavePrompt.__name__, ChatbotsMqNewPrompt.__name__]
+           ChatbotsMqSavePrompt.__name__, ChatbotsMqNewPrompt.__name__,
+           ChatbotsMqSubmindsState.__name__]

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -106,7 +106,7 @@ class ChatbotsMqResponse(KlatContext, MQContext):
     replied_message: Optional[str] = Field(
         default=None, alias="repliedMessage",
         description="ID of the shout being replied to")
-    bot: Literal["0", "1"] = Field(default='0',
+    bot: Literal["0", "1"] = Field(default='0', alias='is_bot',
                                    description="1 if the shout is from a bot")
     prompt_id: Optional[str] = Field(
         default=None, alias="promptID",

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -270,17 +270,10 @@ class ChatbotsMqResponse:
 
 
 class ConnectedSubmind(BaseModel):
-    bot_type: BotType
-    service_name: str
-    # cid: str = Field(deprecated=True)
-    # dom: str = Field(deprecated=True)
-    # conversation_state: CcaiState
-    # responded_shout: Optional[str] = Field(deprecated=True)
-    # shout: Literal["chatbot state"] = Field(deprecated=True)
-    # context: Dict[str, Any]
-    # prompt_id: Optional[str] = Field(deprecated=True)
-    # omit_reply: bool = Field(deprecated=True)
-    # no_save: bool = Field(deprecated=True)
+    bot_type: BotType = Field(
+        description="Type of bot (e.g. facilitator, submind)")  # TODO: Always `submind`?
+    service_name: str = Field(
+        description="Name of the submind")
     attached_cids: List[str] = Field(
         description="List of conversation IDs the submind is participating in")
     supports_raw_shouts: bool = Field(
@@ -297,10 +290,12 @@ class ChatbotsMqSubmindsState(MQContext):
 
     msg_type: Literal["subminds_state"] = Field(
         "subminds_state", description="Message type for SIO", deprecated=True)
-    subminds_per_cid: Dict[str, List[SubmindState]]
-    connected_subminds: Dict[str, ConnectedSubmind]
+    subminds_per_cid: Dict[str, List[SubmindState]] = Field(
+        description="List of submind participants per conversation ID")
+    connected_subminds: Dict[str, ConnectedSubmind] = Field(
+        description="Dict of submind `user_id` to `ConnectedSubmind` object")
     cid_submind_bans: Dict[str, List[str]] = Field(
-        description="List of banned submind `user_id`s per `cid`")
+        description="Dict of `cid` to list of banned submind `user_id`s")
     banned_subminds: List[str] = Field(
         description="List of globally banned submind `user_id`s")
 
@@ -315,7 +310,8 @@ class ChatbotsMqConfiguredPersonasRequest(MQContext):
 class ChatbotsMqConfiguredPersonasResponse(MQContext):
     update_time: datetime = Field(
         description="Time the personas were last checked")
-    items: List[LLMPersona]
+    items: List[LLMPersona] = Field(
+        description="List of configured personas from Klat")
     context: dict = Field(deprecated=True)
 
     @model_validator(mode='before')
@@ -329,7 +325,7 @@ class ChatbotsMqConfiguredPersonasResponse(MQContext):
     def model_dump(self, **kwargs):
         """
         Override model_dump to include 'persona_name' field for each item based 
-        on its 'name' for backwards-compat.
+        on its 'name' for backwards-compat. with Klat server
         """
         data = super().model_dump(**kwargs)
         for item in data['items']:
@@ -406,17 +402,9 @@ class ChatbotsMqSubmindConversationBan(MQContext):
     user_id: str = Field(description="User ID of the submind", alias="nick")
     cid: str = Field(description="Conversation ID to (un)ban submind from")
 
-    class Config:
-        # For aliased fields, accept either the canonical name OR the alias
-        populate_by_name = True
-
 
 class ChatbotsMqSubmindGlobalBan(MQContext):
     user_id: str = Field(description="User ID of the submind", alias="nick")
-
-    class Config:
-        # For aliased fields, accept either the canonical name OR the alias
-        populate_by_name = True
 
 
 class ChatbotsMqSubmindResponseError(MQContext):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -263,7 +263,8 @@ class ChatbotsMqResponse:
     def __new__(cls, *_, **kwargs) -> Union[ChatbotsMqSavePrompt,
                                             ChatbotsMqNewPrompt, 
                                             ChatbotsMqSubmindResponse]:
-        message_text = kwargs.get("message_text") or kwargs.get("messageText")
+        message_text = kwargs.get("message_text") or kwargs.get("messageText") \
+            or kwargs.get("shout")
         
         if message_text == CcaiControl.SAVE_PROMPT_RESULTS.value:
             return ChatbotsMqSavePrompt(**kwargs)

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -128,6 +128,7 @@ class ChatbotsMqResponse(KlatContext, MQContext):
     service_name: Any = Field(default=None, deprecated=True)
     conversation_state: Any = Field(default=None, deprecated=True)
     context: dict = Field(default=None, deprecated=True)
+    dom: Any = Field(default=None, deprecated=True)
     omit_reply: Any = Field(default=None, deprecated=True)
     no_save: Any = Field(default=None, deprecated=True)
 
@@ -162,7 +163,13 @@ class ChatbotsMqResponse(KlatContext, MQContext):
         by_alias = {}
         if 'by_alias' not in kwargs:
             by_alias = super().model_dump(by_alias=True, **kwargs)
+
+            # TODO: Deprecate below serialization patches
             by_alias['isAnnouncement'] = '1' if self.is_announcement else '0'
+            by_alias['nick'] = self.user_id
+            by_alias['responded_shout'] = self.replied_message
+            by_alias['shout'] = self.message_text
+            by_alias['time'] = self.time_created
         
         return {**super().model_dump(**kwargs), **by_alias}
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -231,6 +231,8 @@ class ChatbotsMqSubmindsState(MQContext):
 class ChatbotsMqConfiguredPersonasRequest(MQContext):
     service_name: str = Field(
         description="Name of the service to get personas for")
+    user_id: Optional[str] = Field(
+        default=None, description="Optional user_id making with the request.")
 
 
 class ChatbotsMqConfiguredPersonasResponse(MQContext):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -140,7 +140,8 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
             # Some references use different keys
             # TODO: prevent `None` values from being added here in place of missing
             #  keys
-            values.setdefault("userID", values.get("nick"))
+            if "nick" in values:
+                values.setdefault("userID", values.get("nick"))
 
             if values.get("shout"):
                 values.setdefault("messageText", values.get("shout"))
@@ -182,16 +183,16 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
 
 
 class PromptCompletedContext(BaseModel):
-    prompt: ChatbotsMqRequest
-    is_active: bool
+    prompt: Optional[ChatbotsMqRequest] = None
+    is_active: bool = False
     prompt_text: str
-    available_subminds: List[str]
-    state: int
-    participating_subminds: List[str]
-    proposed_responses: Dict[str, str]
-    submind_opinions: Dict[str, str]
-    votes: Dict[str, str]
-    votes_per_submind: Dict[str, List[str]]
+    available_subminds: List[str] = []
+    state: Optional[int] = None
+    participating_subminds: List[str] = []
+    proposed_responses: Dict[str, str] = {}
+    submind_opinions: Dict[str, str] = {}
+    votes: Dict[str, str] = {}
+    votes_per_submind: Dict[str, List[str]] = {}
     winner: str = ""
 
 
@@ -200,7 +201,7 @@ class ChatbotsMqSavePrompt(ChatbotsMqSubmindResponse):
         default="",
         description="ID of the CCAI prompt associated with the shout")
     prompt_text: str = Field(default="")
-    created_on: str = Field(default="")
+    created_on: Optional[str] = Field(default=None)
     context: PromptCompletedContext = Field(alias="conversation_context")
 
     @model_validator(mode='before')
@@ -213,6 +214,10 @@ class ChatbotsMqSavePrompt(ChatbotsMqSubmindResponse):
 
     def model_dump(self, **kwargs):
         return ChatbotsMqSubmindResponse.model_dump(self, **kwargs)
+
+    class Config:
+        # For aliased fields, accept either the canonical name OR the alias
+        populate_by_name = True
 
 
 class ChatbotsMqNewPrompt(ChatbotsMqSubmindResponse):
@@ -232,7 +237,8 @@ class ChatbotsMqNewPrompt(ChatbotsMqSubmindResponse):
     @classmethod
     def validate_context(cls, values):
         values.setdefault("context", values.get("conversation_context"))
-        values["messageText"] = values.get("prompt_text")
+        if "prompt_text" in values:
+            values["messageText"] = values.get("prompt_text")
         return values
     
     def model_dump(self, **kwargs):
@@ -251,11 +257,11 @@ class ChatbotsMqResponse:
         message_text = kwargs.get("message_text") or kwargs.get("messageText")
         
         if message_text == CcaiControl.SAVE_PROMPT_RESULTS.value:
-            return ChatbotsMqSavePrompt.model_validate(kwargs)
+            return ChatbotsMqSavePrompt(**kwargs)
         elif message_text == CcaiControl.CREATE_PROMPT.value:
-            return ChatbotsMqNewPrompt.model_validate(kwargs)
+            return ChatbotsMqNewPrompt(**kwargs)
         else:
-            return ChatbotsMqSubmindResponse.model_validate(kwargs)
+            return ChatbotsMqSubmindResponse(**kwargs)
     
     ta = TypeAdapter(Union[ChatbotsMqSavePrompt, ChatbotsMqNewPrompt, 
                            ChatbotsMqSubmindResponse])

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -178,6 +178,7 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
         by_alias['responded_shout'] = self.replied_message
         by_alias['shout'] = self.message_text
         by_alias['time'] = self.time_created.timestamp()
+        by_alias['promptState'] = self.prompt_state
         
         return {**super().model_dump(**kwargs), **by_alias}
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -48,7 +48,7 @@ class ChatbotsMqRequest(KlatContext, MQContext):
     prompt_id: Optional[str] = Field(
         default=None,
         description="ID of the CCAI prompt associated with the shout")
-    prompt_state: Optional[int] = Field(
+    prompt_state: Optional[CcaiState] = Field(
         default=None, deprecated=True,
         description="State of the CCAI conversation associated with the shout")
     time_created: datetime = Field(
@@ -130,7 +130,9 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
                               description="Type of submind sending the shout")
 
     # service_name: Any = Field(default=None, deprecated=True)
-    # context: Optional[dict] = Field(default=None, deprecated=True)
+    context: Optional[dict] = Field(
+        default=None, deprecated=True,
+        description="Context used for Klat Server backwards-compat.")
     # dom: Any = Field(default=None, deprecated=True,
     #                  description="Domain of this conversation")
     # omit_reply: bool = Field(

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -169,7 +169,7 @@ class ChatbotsMqResponse(KlatContext, MQContext):
             by_alias['nick'] = self.user_id
             by_alias['responded_shout'] = self.replied_message
             by_alias['shout'] = self.message_text
-            by_alias['time'] = self.time_created
+            by_alias['time'] = self.time_created.timestamp()
         
         return {**super().model_dump(**kwargs), **by_alias}
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -81,11 +81,13 @@ class ChatbotsMqRequest(KlatContext, MQContext):
         )
     
     def model_dump(self, **kwargs):
-        """Override model_dump to include 'bot' field for backwards compatibility"""
+        """
+        Override model_dump to include SIO fields for backwards compatibility
+        """
         data = super().model_dump(**kwargs)
-        # Add the 'bot' parameter as '1' or '0' string for backwards compatibility
-        data["bot"] = "1" if self.from_bot else "0"
+        
         # Add parameters for backwards-compat.
+        data["bot"] = "1" if self.from_bot else "0"
         data["messageText"] = self.message_text
         data["nick"] = self.username
         return data
@@ -123,9 +125,9 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
     source: str = Field(
         default="klat_observer",
         description="Name of the service originating the shout")
-    
     bot_type: BotType = Field(default=None, deprecated=True,
                               description="Type of submind sending the shout")
+
     # service_name: Any = Field(default=None, deprecated=True)
     # context: Optional[dict] = Field(default=None, deprecated=True)
     # dom: Any = Field(default=None, deprecated=True,
@@ -133,9 +135,10 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
     # omit_reply: bool = Field(
     #     default=True, deprecated=True,
     #     description="If true, the Proctor will ignore this message")
-    # no_save: bool = Field(default=False, deprecated=True)
-    created_on: datetime = Field(default=datetime.now(timezone.utc),
-                                 description="Timestamp of response")
+    # no_save: bool = Field(default=False, deprecated=True,
+    #                       description="If true, this message will be ignored")
+    # created_on: datetime = Field(default=datetime.now(timezone.utc),
+    #                              description="Timestamp of response")
     # to_discussion: bool = Field(default=False, deprecated=True)
 
     @model_validator(mode='before')
@@ -148,15 +151,18 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
             if "nick" in values:
                 values.setdefault("userID", values.get("nick"))
 
-            if values.get("shout"):
+            if "shout" in values:
                 values.setdefault("messageText", values.get("shout"))
             
             if values.get("responded_shout"):
                 values.setdefault("repliedMessage",
                                    values.get("responded_shout"))
 
-            if values.get("time"):
+            if "time" in values:
                 values.setdefault("timeCreated", values.get("time"))
+
+            if "created_on" in values:
+                values.setdefault("timeCreated", values.get("created_on"))
 
             if "sid" in values and values["sid"] is None:
                 values.pop("sid")
@@ -166,10 +172,6 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
             #     values['bot_type'] = 'facilitator'
 
         return values
-
-    class Config:
-        # For aliased fields, accept either the canonical name OR the alias
-        populate_by_name = True
 
     def model_dump(self, **kwargs):
         # For backwards-compat, include aliased keys in serialization
@@ -184,6 +186,7 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
         by_alias['shout'] = self.message_text
         by_alias['time'] = self.time_created.timestamp()
         by_alias['promptState'] = self.prompt_state
+        by_alias['created_on'] = self.time_created.timestamp()
         
         return {**super().model_dump(**kwargs), **by_alias}
 
@@ -226,10 +229,6 @@ class ChatbotsMqSavePrompt(ChatbotsMqSubmindResponse):
     def model_dump(self, **kwargs):
         return ChatbotsMqSubmindResponse.model_dump(self, **kwargs)
 
-    class Config:
-        # For aliased fields, accept either the canonical name OR the alias
-        populate_by_name = True
-
 
 class ChatbotsMqNewPrompt(ChatbotsMqSubmindResponse):
     prompt_id: str = Field(
@@ -240,9 +239,6 @@ class ChatbotsMqNewPrompt(ChatbotsMqSubmindResponse):
     context: Optional[dict] = Field(default=None,
                                     alias="conversation_context")
 
-    class Config:
-        # For aliased fields, accept either the canonical name OR the alias
-        populate_by_name = True
 
     @model_validator(mode='before')
     @classmethod
@@ -400,17 +396,9 @@ class ChatbotsMqSubmindConnection(MQContext):
         default=False,
           description="True if the submind supports unprocessed conversations")
 
-    class Config:
-        # For aliased fields, accept either the canonical name OR the alias
-        populate_by_name = True
-
 
 class ChatbotsMqSubmindDisconnection(MQContext):
     user_id: str = Field(description="User ID of the submind", alias="nick")
-
-    class Config:
-        # For aliased fields, accept either the canonical name OR the alias
-        populate_by_name = True
 
 
 class ChatbotsMqSubmindInvitation(MQContext):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -197,6 +197,14 @@ class ChatbotsMqSavePrompt(ChatbotsMqResponse):
     created_on: str = Field(default="")
     context: PromptCompletedContext = Field(alias="conversation_context")
 
+    @model_validator(mode='before')
+    @classmethod
+    def validate_context(cls, values):
+        if "context" in values and not values["context"]:
+            # Pop to replace with `conversation_context` or fail
+            values.pop("context")
+        return values
+
     def model_dump(self, **kwargs):
         return ChatbotsMqResponse.model_dump(self, **kwargs)
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -86,11 +86,18 @@ class ChatbotsMqRequest(KlatContext, MQContext):
         """
         Override model_dump to include SIO fields for backwards compatibility
         """
-        data = super().model_dump(**kwargs)
-        
+
+        # For backwards-compat with Klat Server, include aliased keys in 
+        # serialization. In the future, this should be configurable and
+        # eventually removed.
+        by_alias = {}
+        if 'by_alias' not in kwargs:
+            by_alias = super().model_dump(by_alias=True, **kwargs)
+
         # Add parameters for backwards-compat.
-        data["bot"] = "1" if self.from_bot else "0"
-        return data
+        by_alias["bot"] = "1" if self.from_bot else "0"
+
+        return {**super().model_dump(**kwargs), **by_alias}
 
 
 class ChatbotsMqSubmindResponse(KlatContext, MQContext):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -95,7 +95,7 @@ class ChatbotsMqResponse(KlatContext, MQContext):
     """
     Defines a chatbot response to a request.
     """
-    user_id: str = Field(aliases=['userID', 'nick'], 
+    user_id: str = Field(alias='userID', 
                          description="Unique UID of the sender")
     username: Optional[str] = Field(default=None,
                                     alias="userDisplayName",
@@ -119,12 +119,31 @@ class ChatbotsMqResponse(KlatContext, MQContext):
         default='0', alias="isAnnouncement",
         description="`1` if the shout is an announcement")
     time_created: datetime = Field(
+        alias="time",
         default= datetime.now(tz=timezone.utc), alias="timeCreated",
         description="Timestamp when the shout was created")
     source: str = Field(
         default="klat_observer",
         description="Name of the service originating the shout")
     
+    bot_type = Field(default=None, deprecated=True)
+    service_name = Field(default=None, deprecated=True)
+    conversatino_state = Field(default=None, deprecated=True)
+    context = Field(default=None, deprecated=True)
+    omit_reply = Field(default=None, deprecated=True)
+    no_save = Field(default=None, deprecated=True)
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_uid(cls, values):
+        # Some references use `nick` instead of `user_id` or `userID`
+        values.setdefault("user_id", values.get("nick"))
+
+        # Some reference use `shout` instead of `message_text`
+        values.setdefault("message_text", values.get("shout"))
+
+        values.setdefault("replied_message", values.get("responded_shout"))
+
     class Config:
         # For aliased fields, accept either the canonical name OR the alias
         populate_by_name = True

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -341,10 +341,28 @@ class ChatbotsMqPromptsDataResponse(MQContext):
                    routing_key=request.routing_key)
 
 
+class ChatbotsMqSubmindConnection(MQContext):
+    nick: str = Field(description="User ID of the submind")
+    time: datetime = Field(
+        default= datetime.now(tz=timezone.utc),
+        description="Timestamp when the submind last connected")
+    cids: Optional[List[str]] = Field(
+        default=None, description="List of conversation IDs the submind is in")
+    supports_raw_shouts: bool = Field(
+        default=False,
+          description="True if the submind supports unprocessed conversations")
+
+
+class ChatbotsMqSubmindDisconnection(MQContext):
+    nick: str = Field(description="User ID of the submind")
+
+
 __all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,
            ChatbotsMqSavePrompt.__name__, ChatbotsMqNewPrompt.__name__,
            ChatbotsMqSubmindsState.__name__, 
            ChatbotsMqConfiguredPersonasRequest.__name__,
            ChatbotsMqConfiguredPersonasResponse.__name__,
            ChatbotsMqPromptsDataRequest.__name__,
-           ChatbotsMqPromptsDataResponse.__name__]
+           ChatbotsMqPromptsDataResponse.__name__,
+           ChatbotsMqSubmindConnection.__name__,
+           ChatbotsMqSubmindDisconnection.__name__]

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -80,6 +80,8 @@ class ChatbotRequest(KlatContext, MQContext):
         data = super().model_dump(**kwargs)
         # Add the 'bot' parameter as '1' or '0' string for backwards compatibility
         data["bot"] = "1" if self.from_bot else "0"
+        # Add `messageText` for backwards-compat.
+        data["messageText"] = self.message_text
         return data
 
 

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -24,8 +24,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Optional, List
-from datetime import datetime
+from typing import Literal, Optional, List
+from datetime import datetime, timezone
 from pydantic import Field
 
 from neon_data_models.models.base.contexts import KlatContext, MQContext
@@ -48,6 +48,7 @@ class ChatbotRequest(KlatContext, MQContext):
         default=None, deprecated=True,
         description="State of the CCAI conversation associated with the shout")
     time_created: datetime = Field(
+        default= datetime.now(tz=timezone.utc),
         description="Timestamp when the shout was created")
     requested_participants: Optional[List[str]] = Field(
         default=None, 
@@ -86,4 +87,43 @@ class ChatbotRequest(KlatContext, MQContext):
         return data
 
 
-__all__ = [ChatbotRequest.__name__]
+class ChatbotResponse(KlatContext, MQContext):
+    user_id: str = Field(alias='userID', 
+                         description="Unique UID of the sender")
+    username: Optional[str] = Field(default=None,
+                                    alias="userDisplayName",
+                                    description="Username of the sender")
+    message_text: str = Field(alias="messageText",
+                              description="Text content of the shout")
+    sid: Optional[str] = Field(default=None, alias="messageID",
+                               description="Shout ID")
+    replied_message: Optional[str] = Field(
+        default=None, alias="repliedMessage",
+        description="ID of the shout being replied to")
+    bot: Literal["0", "1"] = Field(default='0',
+                                   description="1 if the shout is from a bot")
+    prompt_id: Optional[str] = Field(
+        default=None, alias="promptID",
+        description="ID of the CCAI prompt associated with the shout")
+    prompt_state: Optional[int] = Field(
+        default=None, deprecated=True, alias="promptState",
+        description="State of the CCAI conversation associated with the shout")
+    is_announcement: Literal["0", "1"] = Field(
+        default='0', alias="isAnnouncement",
+        description="`1` if the shout is an announcement")
+    time_created: datetime = Field(
+        default= datetime.now(tz=timezone.utc), alias="timeCreated",
+        description="Timestamp when the shout was created")
+    source: str = Field(
+        default="klat_observer",
+        description="Name of the service originating the shout")
+    
+    def model_dump(self, **kwargs):
+        """Override model_dump to use by_alias=True by default"""
+        # Set by_alias=True by default if not specified
+        if 'by_alias' not in kwargs:
+            kwargs['by_alias'] = True
+        return super().model_dump(**kwargs)
+
+
+__all__ = [ChatbotRequest.__name__, ChatbotResponse.__name__]

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -138,13 +138,16 @@ class ChatbotSavePrompt(ChatbotResponse):
 
 
 class ChatbotNewPrompt(ChatbotResponse):
-    context: dict
+    user_id = None
+    prompt_text: str = Field(default="")
+    context: Optional[dict] = None
 
 
     @model_validator(mode='before')
     @classmethod
     def validate_context(cls, values):
         values.setdefault("context", values.get("conversation_context"))
+        values["messageText"] = values.get("prompt_text")
         return values
     
     def model_dump(self, **kwargs):

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -365,6 +365,21 @@ class ChatbotsMqSubmindDisconnection(MQContext):
         populate_by_name = True
 
 
+class ChatbotsMqSubmindInvitation(MQContext):
+    cid: str = Field(description="Conversation ID to invite subminds to")
+    requested_participants: List[str] = Field(
+        description="List of submind User IDs to invite to the conversation")
+
+
+class ChatbotsMqUpdateParticipatingSubminds(MQContext):
+    cid: str = Field(description="Conversation ID to update")
+    subminds_to_invite: List[str] = Field(
+        default=[],
+        description="List of submind User IDs to invite to the conversation")
+    subminds_to_kick: List[str] = Field(
+        default=[],
+        description="List of submind User IDs to evict from the conversation")
+
 __all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,
            ChatbotsMqSavePrompt.__name__, ChatbotsMqNewPrompt.__name__,
            ChatbotsMqSubmindsState.__name__, 
@@ -373,4 +388,6 @@ __all__ = [ChatbotsMqRequest.__name__, ChatbotsMqResponse.__name__,
            ChatbotsMqPromptsDataRequest.__name__,
            ChatbotsMqPromptsDataResponse.__name__,
            ChatbotsMqSubmindConnection.__name__,
-           ChatbotsMqSubmindDisconnection.__name__]
+           ChatbotsMqSubmindDisconnection.__name__,
+           ChatbotsMqSubmindInvitation.__name__,
+           ChatbotsMqUpdateParticipatingSubminds.__name__,]

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -39,7 +39,7 @@ class ChatbotsMqRequest(KlatContext, MQContext):
     """
     Defines a request from Klat to the Chatbots service.
     """
-    username: str = Field(description="Username of the sender")
+    username: str = Field(description="Username (or 'nick') of the sender")
     cid: str = Field(description="Conversation ID associated with the shout")
     message_text: str = Field(description="Text content of the shout")
     from_bot: bool = Field(
@@ -95,7 +95,7 @@ class ChatbotsMqResponse(KlatContext, MQContext):
     """
     Defines a chatbot response to a request.
     """
-    user_id: str = Field(alias='userID', 
+    user_id: str = Field(aliases=['userID', 'nick'], 
                          description="Unique UID of the sender")
     username: Optional[str] = Field(default=None,
                                     alias="userDisplayName",

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -215,7 +215,7 @@ class PromptCompletedContext(BaseModel):
 
     # Below are deprecated
     is_active: bool = Field(  # Seems to report active all the time
-        default=False, deprecated=True
+        default=False, deprecated=True,
         description="True if a response has not yet been chosen")
     state: Optional[CcaiState] = Field(
         default=CcaiState.PICK, deprecated=True,

--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -260,10 +260,12 @@ class ChatbotsMqConfiguredPersonasResponse(MQContext):
         return data
 
     @classmethod
-    def from_persona_response(cls, data: dict, service_name: str):
+    def from_persona_request(cls, data: dict,
+                               request: ChatbotsMqConfiguredPersonasRequest):
         data["items"] = [item for item in data["items"]
-                         if service_name in item["supported_llms"]]
-        return cls(**data)
+                         if request.service_name in item["supported_llms"]]
+        return cls(**data, message_id=request.message_id,
+                   routing_key=request.routing_key)
 
 
 class ChatbotsMqPromptsDataRequest(MQContext):

--- a/neon_data_models/models/base/__init__.py
+++ b/neon_data_models/models/base/__init__.py
@@ -24,6 +24,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from enum import Enum
 from os import environ
 from datetime import datetime, timedelta
 from pydantic import ConfigDict, BaseModel as _BaseModel
@@ -60,6 +61,9 @@ class BaseModel(_BaseModel):
         elif isinstance(data, timedelta):
             # Convert timedelta to seconds
             return data.total_seconds()
+        elif isinstance(data, Enum):
+            # Always serialize `Enum` objects by value
+            return data.value
         else:
             # Return other types unchanged
             return data

--- a/neon_data_models/models/base/__init__.py
+++ b/neon_data_models/models/base/__init__.py
@@ -32,8 +32,9 @@ from pydantic import ConfigDict, BaseModel as _BaseModel
 
 class BaseModel(_BaseModel):
     model_config = ConfigDict(extra="allow" if environ.get(
-            "NEON_DATA_MODELS_ALLOW_EXTRA", "false") != "false" else "ignore")
-
+            "NEON_DATA_MODELS_ALLOW_EXTRA", "false") != "false" else "ignore",
+            populate_by_name=environ.get("NEON_DATA_MODELS_POPULATE_BY_NAME",
+                                          "true") != "false",)
         
     def model_dump(self, *args, **kwargs) -> dict:
         """

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -138,7 +138,7 @@ class KlatContext(BaseModel):
 class MQContext(BaseModel):
     routing_key: Optional[str] = None
     message_id: str = Field(default_factory=uuid4().hex,
-                             description="MQ unique message ID")
+                            description="MQ unique message ID")
 
     @model_validator(mode='before')
     @classmethod
@@ -147,4 +147,7 @@ class MQContext(BaseModel):
         Validate MQContext inputs to normalize messageID to message_id.
         """
         values.setdefault("message_id", values.get("messageID"))
+        if values['message_id'] is None:
+            # Allow default_factory to generate a message_id
+            values.pop("message_id")
         return values

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -137,7 +137,7 @@ class KlatContext(BaseModel):
 
 class MQContext(BaseModel):
     routing_key: Optional[str] = None
-    message_id: str = Field(default_factory=uuid4().hex,
+    message_id: str = Field(default_factory=lambda: uuid4().hex,
                             description="MQ unique message ID")
 
     @model_validator(mode='before')

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -26,6 +26,7 @@
 
 from datetime import datetime, timedelta, timezone
 from typing import Literal, List, Optional, Any, Tuple
+from uuid import uuid4
 
 from pydantic import Field, model_validator
 
@@ -136,7 +137,8 @@ class KlatContext(BaseModel):
 
 class MQContext(BaseModel):
     routing_key: Optional[str] = None
-    message_id: str
+    message_id: str = Field(default_factory=uuid4().hex,
+                             description="MQ unique message ID")
 
     @model_validator(mode='before')
     @classmethod

--- a/neon_data_models/types.py
+++ b/neon_data_models/types.py
@@ -28,3 +28,5 @@ from typing import Literal
 
 
 Gender = Literal["male", "female"]
+BotType = Literal["submind", "facilitator"]
+

--- a/neon_data_models/types.py
+++ b/neon_data_models/types.py
@@ -29,4 +29,4 @@ from typing import Literal
 
 Gender = Literal["male", "female"]
 BotType = Literal["submind", "facilitator", "proctor", "observer"]
-# TODO: consider deprecating special facilitator types in `BoType`
+# TODO: consider deprecating special facilitator types in `BotType`

--- a/neon_data_models/types.py
+++ b/neon_data_models/types.py
@@ -28,5 +28,5 @@ from typing import Literal
 
 
 Gender = Literal["male", "female"]
-BotType = Literal["submind", "facilitator"]
-
+BotType = Literal["submind", "facilitator", "proctor", "observer"]
+# TODO: consider deprecating special facilitator types in `BoType`

--- a/tests/models/api/test_chatbots.py
+++ b/tests/models/api/test_chatbots.py
@@ -1,0 +1,73 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2025 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from unittest import TestCase
+from datetime import datetime, timezone
+from pydantic import ValidationError
+
+
+class TestChatbots(TestCase):
+    def test_connected_submind(self):
+        from neon_data_models.models.api.chatbots import ConnectedSubmind
+        
+        # Test minimal creation
+        minimal_submind = ConnectedSubmind(service_name="test_service")
+        self.assertEqual(minimal_submind.service_name, "test_service")
+        self.assertEqual(minimal_submind.attached_cids, [])
+        self.assertIsNone(minimal_submind.version)
+        self.assertFalse(minimal_submind.supports_raw_conversation)
+        self.assertIsInstance(minimal_submind.last_ping, datetime)
+        self.assertEqual(minimal_submind.bot_type, "submind")
+        
+        # Test full definition
+        full_submind = ConnectedSubmind(
+            service_name="full_service",
+            attached_cids=["cid1", "cid2"],
+            version="1.0.0",
+            supports_raw_conversation=True
+        )
+        self.assertEqual(full_submind.service_name, "full_service")
+        self.assertEqual(full_submind.attached_cids, ["cid1", "cid2"])
+        self.assertEqual(full_submind.version, "1.0.0")
+        self.assertTrue(full_submind.supports_raw_conversation)
+        
+        # Test alias
+        cids_submind = ConnectedSubmind(
+            service_name="cids_service",
+            cids=["cid3"]
+        )
+        self.assertEqual(cids_submind.attached_cids, ["cid3"])
+        
+        # Test validation
+        with self.assertRaises(ValidationError):
+            ConnectedSubmind()  # Missing required field service_name
+        
+        # Test datetime factory
+        import time
+        submind1 = ConnectedSubmind(service_name="time_test")
+        time.sleep(0.1)
+        submind2 = ConnectedSubmind(service_name="time_test_2")
+        self.assertLess(submind1.last_ping, submind2.last_ping)

--- a/tests/models/api/test_llm.py
+++ b/tests/models/api/test_llm.py
@@ -37,6 +37,11 @@ class TestLLM(TestCase):
         self.assertEqual(legacy_mq_persona.system_prompt,
                          legacy_mq_persona.description)
 
+        # By alias
+        alias_mq_persona = LLMPersona(persona_name="my persona",
+                                      description="You are a helpful chatbot.")
+        self.assertEqual(alias_mq_persona, legacy_mq_persona)
+
         # Valid system prompt
         legacy_bf_persona = LLMPersona(name="neon",
                                        system_prompt="You are NeonLLM.")

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1153,7 +1153,7 @@ class TestChatbotsMQ(TestCase):
         new_prompt = ChatbotsMqNewPrompt(**valid_kwargs)
         self.assertIsInstance(new_prompt, ChatbotsMqNewPrompt)
         self.assertEqual(new_prompt.user_id, "user123")
-        self.assertEqual(new_prompt.message_text, "Test prompt text")
+        self.assertEqual(new_prompt.message_text, valid_kwargs["messageText"])
         self.assertEqual(new_prompt.prompt_id, "prompt123")
         self.assertEqual(new_prompt.prompt_text, "Test prompt text")
         self.assertIsNone(new_prompt.context)
@@ -1181,9 +1181,8 @@ class TestChatbotsMQ(TestCase):
             "prompt_text": "Only prompt text",
             "conversation_state": 0
         }
-        
-        partial_prompt = ChatbotsMqNewPrompt(**partial_kwargs)
-        self.assertEqual(partial_prompt.message_text, "Only prompt text")
+        with self.assertRaises(ValidationError):
+            partial_prompt = ChatbotsMqNewPrompt(**partial_kwargs)
         
         # Test model_dump inheritance from ChatbotsMqResponse
         serialized = new_prompt.model_dump()
@@ -1292,10 +1291,10 @@ class TestChatbotsMQ(TestCase):
         # Test validation logic for deprecated fields
         deprecated_kwargs = valid_kwargs.copy()
         deprecated_kwargs["bot_type"] = "proctor"
-        deprecated_kwargs["shout"] = "hello"
+        # deprecated_kwargs["shout"] = "hello"
         submind = ConnectedSubmind(**deprecated_kwargs)
         self.assertIsInstance(submind.bot_type, str)
-        self.assertEqual(submind.shout, "chatbot state")
+        # self.assertEqual(submind.shout, "chatbot state")
 
     def test_chatbots_mq_subminds_state(self):
         from neon_data_models.models.api.mq.chatbots import ChatbotsMqSubmindsState, ConnectedSubmind
@@ -1658,6 +1657,7 @@ class TestChatbotsMQ(TestCase):
             "replied_message": None,
             "bot": "1",
             "prompt_id": "f747c1f3caeb4975983b2eb52c35491e",
+            "prompt_text": "Why is testing important?",
             "prompt_state": 1,
             "is_announcement": False,
             "time_created": current_time,
@@ -1695,7 +1695,6 @@ class TestChatbotsMQ(TestCase):
         result = ChatbotsMqResponse(**new_prompt_message)
         self.assertIsInstance(result, ChatbotsMqNewPrompt)
         self.assertEqual(result.prompt_id, new_prompt_message['prompt_id'])
-        self.assertEqual(result.prompt_text, '')
         
         alt_response = ChatbotsMqResponse(**alt_new_prompt_message)
         self.assertIsInstance(alt_response, ChatbotsMqNewPrompt)
@@ -1746,67 +1745,67 @@ class TestChatbotsMQ(TestCase):
             "time": "1743539090",
             "omit_reply": True,
             "conversation_context": {
-            "message_id": "66d5c444961243d9bf95c5a068b0211a",
-            "state": 4,
-            "prompt": {
-                "routing_key": None,
-                "message_id": "98add3204f",
-                "sid": "7f80ae0d-a5a9-440d-f113-df167b70be9e",
-                "cid": "35d5dff220",
-                "title": "",
-                "username": "ca45d1ea45134523af7f",
-                "message_text": "Why is testing important?",
-                "from_bot": False,
-                "prompt_id": "00cbbd4c9f33422f9628c7b0c2e90c5b",
-                "prompt_state": None,
-                "time_created": 1743539036.0,
-                "requested_participants": [
-                "proctor"
+                "message_id": "66d5c444961243d9bf95c5a068b0211a",
+                "state": 4,
+                "prompt": {
+                    "routing_key": None,
+                    "message_id": "98add3204f",
+                    "sid": "7f80ae0d-a5a9-440d-f113-df167b70be9e",
+                    "cid": "35d5dff220",
+                    "title": "",
+                    "username": "ca45d1ea45134523af7f",
+                    "message_text": "Why is testing important?",
+                    "from_bot": False,
+                    "prompt_id": "00cbbd4c9f33422f9628c7b0c2e90c5b",
+                    "prompt_state": None,
+                    "time_created": 1743539036.0,
+                    "requested_participants": [
+                    "proctor"
+                    ],
+                    "recipient": None,
+                    "bound_service": "",
+                    "bot": "0",
+                    "messageText": "Why is testing important?",
+                    "nick": "ca45d1ea45134523af7f"
+                },
+                "is_active": True,
+                "prompt_text": "Why is testing important?",
+                "available_subminds": [
+                    "nucleotidings_vllm",
+                    "logistics_vllm",
+                    "neon_vllm"
                 ],
-                "recipient": None,
-                "bound_service": "",
-                "bot": "0",
-                "messageText": "Why is testing important?",
-                "nick": "ca45d1ea45134523af7f"
-            },
-            "is_active": True,
-            "prompt_text": "Why is testing important?",
-            "available_subminds": [
-                "nucleotidings_vllm",
-                "logistics_vllm",
-                "neon_vllm"
-            ],
-            "nick_mapping": {},
-            "participating_subminds": [
-                "nucleotidings_vllm",
-                "logistics_vllm",
-                "neon_vllm"
-            ],
-            "proposed_responses": {
-                "neon_vllm": "Testing is crucial.",
-                "logistics_vllm": "Testing is important.",
-                "nucleotidings_vllm": "Testing is important."
-            },
-            "submind_opinions": {
-                "neon_vllm": "The answer provided by \"logistics_vllm\" is the best answer",
-                "nucleotidings_vllm": "The answer provided by 'logistics_vllm' is considered the best.",
-                "logistics_vllm": "The answer provided by \"nucleotidings_vllm\" is the best answer."
-            },
-            "votes": {
-                "neon_vllm": "logistics_vllm",
-                "logistics_vllm": "nucleotidings_vllm",
-                "nucleotidings_vllm": "logistics_vllm"
-            },
-            "votes_per_submind": {
-                "logistics_vllm": [
-                "neon_vllm",
-                "nucleotidings_vllm"
+                "nick_mapping": {},
+                "participating_subminds": [
+                    "nucleotidings_vllm",
+                    "logistics_vllm",
+                    "neon_vllm"
                 ],
-                "nucleotidings_vllm": [
-                "logistics_vllm"
-                ]
-            },
-            "winner": "logistics_vllm"
+                "proposed_responses": {
+                    "neon_vllm": "Testing is crucial.",
+                    "logistics_vllm": "Testing is important.",
+                    "nucleotidings_vllm": "Testing is important."
+                },
+                "submind_opinions": {
+                    "neon_vllm": "The answer provided by \"logistics_vllm\" is the best answer",
+                    "nucleotidings_vllm": "The answer provided by 'logistics_vllm' is considered the best.",
+                    "logistics_vllm": "The answer provided by \"nucleotidings_vllm\" is the best answer."
+                },
+                "votes": {
+                    "neon_vllm": "logistics_vllm",
+                    "logistics_vllm": "nucleotidings_vllm",
+                    "nucleotidings_vllm": "logistics_vllm"
+                },
+                "votes_per_submind": {
+                    "logistics_vllm": [
+                    "neon_vllm",
+                    "nucleotidings_vllm"
+                    ],
+                    "nucleotidings_vllm": [
+                    "logistics_vllm"
+                    ]
+                },
+                "winner": "logistics_vllm"
             },
             "no_save": False,
             "message_id": "6924c0422b9347ae9604e4e97cd0847a",
@@ -1816,7 +1815,6 @@ class TestChatbotsMQ(TestCase):
         result = ChatbotsMqResponse(**save_prompt_message)
         self.assertIsInstance(result, ChatbotsMqSavePrompt)
         self.assertEqual(result.prompt_id, "prompt_123")
-        self.assertEqual(result.prompt_text, "")
         # self.assertIsNone(result.created_on)
         self.assertEqual(result.context.winner, "submind1")
         self.assertIsInstance(ChatbotsMqResponse(**alt_save_prompt_message),

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1115,7 +1115,7 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(save_prompt.message_text, "Prompt completed")
         self.assertEqual(save_prompt.prompt_id, "prompt123")
         self.assertEqual(save_prompt.prompt_text, "Test prompt text")
-        self.assertEqual(save_prompt.created_on, "2023-01-01")
+        # self.assertEqual(save_prompt.created_on, "2023-01-01")
         self.assertEqual(save_prompt.context, context)
         
         # Test model_dump inheritance from ChatbotsMqResponse
@@ -1724,12 +1724,12 @@ class TestChatbotsMQ(TestCase):
             "context": {
                 "winner": "submind1",
                 "prompt_text": "Test prompt",
-                "created_on": "2023-01-01"
+                # "created_on": "2023-01-01"
             },
             "dom": "",
             "omit_reply": True,
             "no_save": False,
-            "created_on": None,
+            # "created_on": None,
             "to_discussion": None
         }
         alt_save_prompt_message = {

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1840,7 +1840,7 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(connection.time, current_time)
         
         # Test with all fields
-        full_kwargs = {
+        minimal_kwargs = {
             "user_id": "submind2",
             "time": current_time,
             "cids": ["conversation1", "conversation2"],
@@ -1848,12 +1848,21 @@ class TestChatbotsMQ(TestCase):
             "message_id": "test_message_id"
         }
         
-        full_connection = ChatbotsMqSubmindConnection(**full_kwargs)
+        full_connection = ChatbotsMqSubmindConnection(**minimal_kwargs)
         self.assertEqual(full_connection.user_id, "submind2")
         self.assertEqual(full_connection.cids, ["conversation1", "conversation2"])
         
-        # # Test alias interchangeability (populate_by_name config)
-        # self.assertEqual(full_connection.user_id, full_connection.nick)
+        # With context
+        minimal_kwargs = {
+            "user_id": "submind_2-longuuidstring",
+            "time": current_time,
+            "cids": ["conversation1", "conversation2"],
+            "supports_raw_conversation": True,
+            "message_id": "test_message_id",
+            "context": {}
+        }
+        parsed_service_name = ChatbotsMqSubmindConnection(**minimal_kwargs)
+        self.assertEqual(parsed_service_name.context.service_name, "submind_2")
         
         # Test missing required fields
         with self.assertRaises(ValidationError):
@@ -2004,3 +2013,95 @@ class TestChatbotsMQ(TestCase):
         # Test missing required fields
         with self.assertRaises(ValidationError):
             ChatbotsMqSubmindGlobalBan(message_id="test_id")
+
+    def test_chatbots_mq_submind_response_error(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqSubmindResponseError
+        
+        # Test basic initialization
+        valid_kwargs = {
+            "message": "An error occurred",
+            "message_id": "test_message_id"
+        }
+        
+        error_response = ChatbotsMqSubmindResponseError(**valid_kwargs)
+        self.assertIsInstance(error_response, ChatbotsMqSubmindResponseError)
+        self.assertEqual(error_response.message, "An error occurred")
+        self.assertEqual(error_response.message_id, "test_message_id")
+        
+        # Test with alias field
+        alias_kwargs = {
+            "msg": "An error with alias field",
+            "message_id": "test_message_id"
+        }
+        
+        alias_response = ChatbotsMqSubmindResponseError(**alias_kwargs)
+        self.assertEqual(alias_response.message, "An error with alias field")
+        
+        # Test serialization
+        serialized = error_response.model_dump()
+        self.assertEqual(serialized["message"], "An error occurred")
+        
+        # Test by_alias serialization
+        serialized_alias = error_response.model_dump(by_alias=True)
+        self.assertEqual(serialized_alias["msg"], "An error occurred")
+        
+        # Test without message (should be None by default)
+        no_message = ChatbotsMqSubmindResponseError(message_id="test_message_id")
+        self.assertIsNone(no_message.message)
+
+    def test_chatbots_mq_response_edge_cases(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqResponse
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqSubmindResponse
+        
+        # Test with empty/minimal valid message
+        minimal_message = {
+            "userID": "test_user",
+            "messageText": "",
+            "message_id": "test_message_id"
+        }
+        
+        result = ChatbotsMqResponse(**minimal_message)
+        self.assertIsInstance(result, ChatbotsMqSubmindResponse)
+        self.assertEqual(result.message_text, "")
+        
+        # Test with mixed aliased and non-aliased fields
+        mixed_fields = {
+            "userID": "test_user",
+            "shout": "Using aliased shout field",
+            "message_id": "test_message_id",
+            "nick": "nick_value"  # This should be used for user_id too
+        }
+        
+        result = ChatbotsMqResponse(**mixed_fields)
+        self.assertIsInstance(result, ChatbotsMqSubmindResponse)
+        self.assertEqual(result.message_text, "Using aliased shout field")
+        self.assertEqual(result.user_id, "test_user")  # userID takes precedence over nick
+        
+        # Test with malformed timestamps that should be converted
+        timestamp_message = {
+            "userID": "test_user",
+            "messageText": "Timestamp test",
+            "created_on": "1611234567",  # String timestamp
+            "time": 1611234567,  # Integer timestamp
+            "message_id": "test_message_id"
+        }
+        
+        result = ChatbotsMqResponse(**timestamp_message)
+        self.assertIsInstance(result, ChatbotsMqSubmindResponse)
+        # Ensure the timestamps are properly handled in serialization
+        serialized = result.model_dump(by_alias=True)
+        self.assertEqual(serialized["created_on"], 1611234567)
+        
+        # Test with null/None fields that should be handled
+        null_fields = {
+            "userID": "test_user",
+            "messageText": "Test with nulls",
+            "message_id": "test_message_id",
+            "sid": None,  # Should be handled by the model validator
+            "repliedMessage": None,
+            "promptID": None
+        }
+        
+        result = ChatbotsMqResponse(**null_fields)
+        self.assertIsInstance(result, ChatbotsMqSubmindResponse)
+        self.assertEqual(result.sid, "")  # Default value when None is provided

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -931,7 +931,7 @@ class TestChatbotsMQ(TestCase):
         sio_request = ChatbotsMqRequest.from_sio_message(sio_message)
         self.assertEqual(sio_request.username, "user_id")
 
-    def test_chatbots_mq_response(self):
+    def test_chatbots_mq_submind_response(self):
         from neon_data_models.models.api.mq.chatbots import ChatbotsMqResponse, ChatbotsMqSubmindResponse
         
         # Test basic initialization with required fields
@@ -994,7 +994,7 @@ class TestChatbotsMQ(TestCase):
         self.assertIn("promptID", serialized)
         self.assertIn("isAnnouncement", serialized)
         self.assertIn("timeCreated", serialized)
-        
+
         # Test invalid literal values
         with self.assertRaises(ValidationError):
             ChatbotsMqResponse(
@@ -1113,6 +1113,8 @@ class TestChatbotsMQ(TestCase):
             "context": context
         }
         
+        # Test Descriminator
+        
         save_prompt = ChatbotsMqSavePrompt(**valid_kwargs)
         self.assertIsInstance(save_prompt, ChatbotsMqSavePrompt)
         self.assertEqual(save_prompt.user_id, "user123")
@@ -1154,6 +1156,9 @@ class TestChatbotsMQ(TestCase):
             "conversation_state": 0
         }
         
+        # Test Descriminator
+
+
         new_prompt = ChatbotsMqNewPrompt(**valid_kwargs)
         self.assertIsInstance(new_prompt, ChatbotsMqNewPrompt)
         self.assertEqual(new_prompt.user_id, "user123")
@@ -1649,58 +1654,76 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(result.user_id, "submind1")
         self.assertEqual(result.message_text, "Regular response")
         
+        # Test new prompt message
+        new_prompt_message = {
+            "routing_key": None,
+            "message_id": "8ee915f080ae416da1f31081cc4f945a",
+            "sid": "",
+            "cid": "35d5dff220",
+            "title": "",
+            "user_id": "proctor-f3277918bcc947359994f711452450b6",
+            "username": None,
+            "message_text": "!MSG:CREATE_PROMPT",
+            "replied_message": None,
+            "bot": "1",
+            "prompt_id": "f747c1f3caeb4975983b2eb52c35491e",
+            "prompt_state": 1,
+            "is_announcement": False,
+            "time_created": current_time,
+            "source": "klat_observer",
+            "bot_type": "proctor",
+            "service_name": "proctor",
+            "context": {},
+            "dom": "",
+            "omit_reply": True,
+            "no_save": False,
+            "created_on": 1743531762,
+            "to_discussion": None
+        }
+
+        result = ChatbotsMqResponse(**new_prompt_message)
+        self.assertIsInstance(result, ChatbotsMqNewPrompt)
+        self.assertEqual(result.prompt_id, new_prompt_message['prompt_id'])
+        self.assertEqual(result.prompt_text, '')
+        
         # Test save prompt message
         save_prompt_message = {
-            "userID": "submind1",
-            "messageText": CcaiControl.SAVE_PROMPT_RESULTS.value,
+            "routing_key": None,
+            "message_id": "e2ad6e92438f4ec0acaa386e22e24954",
+            "sid": "",
+            "cid": "35d5dff220",
+            "title": "",
+            "user_id": "proctor-f3277918bcc947359994f711452450b6",
+            "username": None,
+            "message_text": "!MSG:SAVE_PROMPT_RESULTS",
+            "replied_message": None,
+            "bot": "1",
             "prompt_id": "prompt_123",
-            "prompt_text": "Test prompt",
-            "created_on": "2023-01-01",
-            "message_id": "test_message_id",
-            "conversation_state": 0,
-            "conversation_context": {
-                "prompt": {
-                    "username": "test_user",
-                    "cid": "test_conversation",
-                    "message_text": "Original prompt",
-                    "message_id": "original_message_id",
-                    "time_created": current_time
-                },
-                "is_active": False,
-                "prompt_text": "Original prompt",
-                "available_subminds": ["submind1", "submind2"],
-                "state": 2,
-                "participating_subminds": ["submind1"],
-                "proposed_responses": {"submind1": "Response 1"},
-                "submind_opinions": {"submind1": "Opinion 1"},
-                "votes": {"submind1": "vote1"},
-                "votes_per_submind": {"submind1": ["vote1"]},
-                "winner": "submind1"
-            }
+            "prompt_state": 4,
+            "is_announcement": False,
+            "time_created": current_time,
+            "source": "klat_observer",
+            "bot_type": "proctor",
+            "service_name": "proctor",
+            "context": {
+                "winner": "submind1",
+                "prompt_text": "Test prompt",
+                "created_on": "2023-01-01"
+            },
+            "dom": "",
+            "omit_reply": True,
+            "no_save": False,
+            "created_on": None,
+            "to_discussion": None
         }
         
         result = ChatbotsMqResponse(**save_prompt_message)
         self.assertIsInstance(result, ChatbotsMqSavePrompt)
         self.assertEqual(result.prompt_id, "prompt_123")
-        self.assertEqual(result.prompt_text, "Test prompt")
-        self.assertEqual(result.created_on, "2023-01-01")
+        self.assertEqual(result.prompt_text, "")
+        self.assertIsNone(result.created_on)
         self.assertEqual(result.context.winner, "submind1")
-        
-        # Test new prompt message
-        new_prompt_message = {
-            "userID": "submind1",
-            "messageText": CcaiControl.CREATE_PROMPT.value,
-            "prompt_id": "prompt_456",
-            "prompt_text": "New test prompt",
-            "conversation_state": 2,
-            "message_id": "test_message_id"
-        }
-        
-        result = ChatbotsMqResponse(**new_prompt_message)
-        self.assertIsInstance(result, ChatbotsMqNewPrompt)
-        self.assertEqual(result.prompt_id, "prompt_456")
-        self.assertEqual(result.prompt_text, "New test prompt")
-        
+
         # Test with message_text vs messageText
         alternate_syntax = {
             "userID": "submind1",

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1006,4 +1006,124 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(both_names_request.username, "display_name")
         self.assertEqual(both_names_request.cid, "test_conversation")
         self.assertEqual(both_names_request.message_text, "Hello, how are you?")
+    
+    def test_chatbot_response(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotResponse
+        from datetime import datetime, timezone
+        
+        # Test basic initialization with required fields
+        current_time = datetime.now(tz=timezone.utc)
+        valid_kwargs = {
+            "userID": "user123",
+            "messageText": "Hello, this is a response",
+            "message_id": "test_message_id"  # Added required message_id
+        }
+        
+        response = ChatbotResponse(**valid_kwargs)
+        self.assertIsInstance(response, ChatbotResponse)
+        self.assertEqual(response.user_id, "user123")
+        self.assertEqual(response.message_text, "Hello, this is a response")
+        self.assertEqual(response.bot, "0")  # Default value check
+        self.assertEqual(response.is_announcement, "0")  # Default value check
+        
+        # Test with all fields
+        full_kwargs = {
+            "userID": "user123",
+            "userDisplayName": "John Doe",
+            "messageText": "Hello, this is a complete response",
+            "messageID": "msg123",
+            "repliedMessage": "original_msg456",
+            "bot": "1",
+            "promptID": "prompt789",
+            "promptState": 2,
+            "isAnnouncement": "1",
+            "timeCreated": current_time,
+            "source": "test_source",
+            "client": "test_client",
+            "cid": "conversation123",
+            "message_id": "message123"
+        }
+        
+        full_response = ChatbotResponse(**full_kwargs)
+        self.assertIsInstance(full_response, ChatbotResponse)
+        self.assertEqual(full_response.user_id, "user123")
+        self.assertEqual(full_response.username, "John Doe")
+        self.assertEqual(full_response.message_text, "Hello, this is a complete response")
+        self.assertEqual(full_response.sid, "msg123")
+        self.assertEqual(full_response.replied_message, "original_msg456")
+        self.assertEqual(full_response.bot, "1")
+        self.assertEqual(full_response.prompt_id, "prompt789")
+        self.assertEqual(full_response.prompt_state, 2)
+        self.assertEqual(full_response.is_announcement, "1")
+        self.assertEqual(full_response.time_created, current_time)
+        self.assertEqual(full_response.source, "test_source")
+        self.assertEqual(full_response.cid, "conversation123")
+        self.assertEqual(full_response.message_id, "message123")
+        
+        # Test with default time_created
+        response_with_default_time = ChatbotResponse(
+            userID="user456",
+            messageText="Response with default time",
+            message_id="test_mid_default_time"  # Added required message_id
+        )
+        self.assertIsInstance(response_with_default_time.time_created, datetime)
+        
+        # Test field aliases
+        aliased_data = {
+            "userID": "user123",
+            "userDisplayName": "John Doe",
+            "messageText": "Testing aliases",
+            "messageID": "alias_msg_id",
+            "promptID": "alias_prompt_id",
+            "message_id": "test_mid_aliases"  # Added required message_id
+        }
+        
+        aliased_response = ChatbotResponse(**aliased_data)
+        self.assertEqual(aliased_response.user_id, "user123")
+        self.assertEqual(aliased_response.username, "John Doe")
+        self.assertEqual(aliased_response.message_text, "Testing aliases")
+        self.assertEqual(aliased_response.sid, "alias_msg_id")
+        self.assertEqual(aliased_response.prompt_id, "alias_prompt_id")
+        
+        # Test invalid bot value
+        with self.assertRaises(ValidationError):
+            ChatbotResponse(userID="user123", messageText="Test", bot="2", 
+                           message_id="test_mid_invalid_bot")  # Added required message_id
+            
+        # Test invalid is_announcement value
+        with self.assertRaises(ValidationError):
+            ChatbotResponse(userID="user123", messageText="Test", isAnnouncement="2",
+                           message_id="test_mid_invalid_announcement")  # Added required message_id
+            
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotResponse(userDisplayName="John Doe", message_id="test_mid_missing_userID")
+            
+        with self.assertRaises(ValidationError):
+            ChatbotResponse(userID="user123", message_id="test_mid_missing_messageText")
+            
+        with self.assertRaises(ValidationError):
+            ChatbotResponse(userID="user123", messageText="Missing message_id")
+            
+        # Test model serialization with exclude_none
+        response_with_none = ChatbotResponse(
+            userID="user123",
+            messageText="Test exclude_none",
+            username=None,
+            promptID=None,
+            message_id="test_mid_exclude_none"  # Added required message_id
+        )
+        serialized_with_none = response_with_none.model_dump()
+        serialized_without_none = response_with_none.model_dump()
+        
+        # Fix: Check for attribute names, not alias names in serialized output
+        self.assertIn("userDisplayName", serialized_with_none)
+        self.assertIn("promptID", serialized_with_none)
+        # self.assertNotIn("userDisplayName", serialized_without_none)
+        # self.assertNotIn("promptID", serialized_without_none)
+        
+        # Test model serialization with by_alias=True to get the field aliases instead
+        serialized_with_alias = response_with_none.model_dump()
+        self.assertIn("userDisplayName", serialized_with_alias)
+        self.assertIn("promptID", serialized_with_alias)
 

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1369,3 +1369,125 @@ class TestChatbotsMQ(TestCase):
                 # Missing other required fields
             )
 
+    def test_chatbots_mq_configured_personas_request(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqConfiguredPersonasRequest
+        
+        # Test valid initialization
+        valid_request = ChatbotsMqConfiguredPersonasRequest(
+            service_name="test_service",
+            message_id="test_message_id"
+        )
+        self.assertIsInstance(valid_request, ChatbotsMqConfiguredPersonasRequest)
+        self.assertEqual(valid_request.service_name, "test_service")
+        self.assertEqual(valid_request.message_id, "test_message_id")
+        
+        # Test serialization
+        serialized = valid_request.model_dump()
+        self.assertEqual(serialized["service_name"], "test_service")
+        self.assertEqual(serialized["message_id"], "test_message_id")
+        
+        # Test missing MQ required data
+        with self.assertRaises(ValidationError):
+            ChatbotsMqConfiguredPersonasRequest(service_name="test_service")
+        
+        # Test missing service_name
+        with self.assertRaises(ValidationError):
+            ChatbotsMqConfiguredPersonasRequest(message_id="test_message_id")
+
+    def test_chatbots_mq_configured_personas_response(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqConfiguredPersonasResponse
+        from neon_data_models.models.api.llm import LLMPersona
+        
+        # Create test data
+        current_time = datetime.now(tz=timezone.utc)
+        test_personas = [
+            LLMPersona(
+                name="persona1",
+                system_prompt="System prompt 1",
+                # supported_llms=["test_service", "another_service"]
+            ),
+            LLMPersona(
+                name="persona2",
+                system_prompt="System prompt 2",
+                # supported_llms=["test_service"]
+            )
+        ]
+        
+        # Test valid initialization
+        valid_response = ChatbotsMqConfiguredPersonasResponse(
+            update_time=current_time,
+            items=test_personas,
+            message_id="test_message_id"
+        )
+        self.assertIsInstance(valid_response, ChatbotsMqConfiguredPersonasResponse)
+        self.assertEqual(valid_response.update_time, current_time)
+        self.assertEqual(len(valid_response.items), 2)
+        self.assertEqual(valid_response.items[0].name, "persona1")
+        self.assertEqual(valid_response.items[1].name, "persona2")
+        
+        # Test model_dump behavior with persona_name addition
+        serialized = valid_response.model_dump()
+        self.assertEqual(serialized["items"][0]["persona_name"], "persona1")
+        self.assertEqual(serialized["items"][1]["persona_name"], "persona2")
+        
+        # Test from_persona_response method
+        response_data = {
+            "update_time": current_time,
+            "items": [
+                {
+                    "name": "persona1",
+                    "system_prompt": "System prompt 1",
+                    "supported_llms": ["test_service", "another_service"]
+                },
+                {
+                    "name": "persona2",
+                    "system_prompt": "System prompt 2",
+                    "supported_llms": ["test_service"]
+                },
+                {
+                    "name": "persona3",
+                    "system_prompt": "System prompt 3",
+                    "supported_llms": ["another_service"]
+                }
+            ],
+            "message_id": "test_message_id"
+        }
+        
+        filtered_response = ChatbotsMqConfiguredPersonasResponse.from_persona_response(
+            response_data, "test_service"
+        )
+        self.assertEqual(len(filtered_response.items), 2)  # Only personas with "test_service" in supported_llms
+        self.assertEqual(filtered_response.items[0].name, "persona1")
+        self.assertEqual(filtered_response.items[1].name, "persona2")
+        
+        # Test backward compatibility - omitting context
+        response_without_context = ChatbotsMqConfiguredPersonasResponse(
+            update_time=current_time,
+            items=test_personas,
+            message_id="test_message_id"
+        )
+        self.assertIsInstance(
+            response_without_context.context['mq']['message_id'], str)
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqConfiguredPersonasResponse(
+                update_time=current_time,
+                items=test_personas
+                # Missing message_id
+            )
+            
+        with self.assertRaises(ValidationError):
+            ChatbotsMqConfiguredPersonasResponse(
+                message_id="test_message_id",
+                items=test_personas
+                # Missing update_time
+            )
+            
+        with self.assertRaises(ValidationError):
+            ChatbotsMqConfiguredPersonasResponse(
+                message_id="test_message_id",
+                update_time=current_time
+                # Missing items
+            )
+

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1844,7 +1844,6 @@ class TestChatbotsMQ(TestCase):
         self.assertIsInstance(connection, ChatbotsMqSubmindConnection)
         self.assertEqual(connection.user_id, "submind1")  # Check aliased field
         self.assertEqual(connection.time, current_time)
-        self.assertFalse(connection.supports_raw_conversation)  # Default value
         
         # Test with all fields
         full_kwargs = {
@@ -1858,7 +1857,6 @@ class TestChatbotsMQ(TestCase):
         full_connection = ChatbotsMqSubmindConnection(**full_kwargs)
         self.assertEqual(full_connection.user_id, "submind2")
         self.assertEqual(full_connection.cids, ["conversation1", "conversation2"])
-        self.assertTrue(full_connection.supports_raw_conversation)
         
         # # Test alias interchangeability (populate_by_name config)
         # self.assertEqual(full_connection.user_id, full_connection.nick)

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1647,7 +1647,7 @@ class TestChatbotsMQ(TestCase):
         # Test save prompt message
         save_prompt_message = {
             "userID": "submind1",
-            "messageText": CcaiControl.SAVE_PROMPT_RESULTS,
+            "messageText": CcaiControl.SAVE_PROMPT_RESULTS.value,
             "prompt_id": "prompt_123",
             "prompt_text": "Test prompt",
             "created_on": "2023-01-01",
@@ -1684,7 +1684,7 @@ class TestChatbotsMQ(TestCase):
         # Test new prompt message
         new_prompt_message = {
             "userID": "submind1",
-            "messageText": CcaiControl.CREATE_PROMPT,
+            "messageText": CcaiControl.CREATE_PROMPT.value,
             "prompt_id": "prompt_456",
             "prompt_text": "New test prompt",
             "conversation_state": 2,

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1243,3 +1243,129 @@ class TestChatbotsMQ(TestCase):
         # These tests verify that the classes are properly defined and usable
         # even with the new names
 
+    def test_connected_submind(self):
+        from neon_data_models.models.api.mq.chatbots import ConnectedSubmind
+        from neon_data_models.enum import CcaiState
+        from neon_data_models.types import BotType
+        
+        # Test valid initialization with required fields
+        current_time = datetime.now(tz=timezone.utc)
+        valid_kwargs = {
+            "message_id": "test_message_id",
+            "bot_type": "submind",
+            "service_name": "test_service",
+            "cid": "test_conversation",
+            "dom": "test_domain",
+            "conversation_state": CcaiState.IDLE,
+            "responded_shout": "test_shout_id",
+            "shout": "chatbot state",
+            "context": {"key": "value"},
+            "prompt_id": "test_prompt_id",
+            "omit_reply": False,
+            "no_save": False,
+            "attached_cids": ["cid1", "cid2"],
+            "supports_raw_shouts": True,
+            "last_ping": current_time
+        }
+        
+        submind = ConnectedSubmind(**valid_kwargs)
+        self.assertIsInstance(submind, ConnectedSubmind)
+        self.assertIsInstance(submind.bot_type, str)
+        self.assertEqual(submind.service_name, "test_service")
+        self.assertEqual(submind.attached_cids, ["cid1", "cid2"])
+        self.assertEqual(submind.last_ping, current_time)
+        self.assertTrue(submind.supports_raw_shouts)
+        
+        # Test model_dump functionality
+        serialized = submind.model_dump()
+        self.assertIsInstance(serialized["bot_type"], str)
+        self.assertEqual(serialized["service_name"], "test_service")
+        self.assertEqual(serialized["attached_cids"], ["cid1", "cid2"])
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ConnectedSubmind(
+                message_id="test_message_id",
+                service_name="test_service"
+                # Missing other required fields
+            )
+
+    def test_chatbots_mq_subminds_state(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqSubmindsState, ConnectedSubmind
+        from neon_data_models.enum import SubmindStatus
+        from neon_data_models.models.api.mq.chatbots import CcaiState
+        from datetime import datetime, timezone
+        
+        # Create test ConnectedSubmind for use in the test
+        current_time = datetime.now(tz=timezone.utc)
+        connected_submind = ConnectedSubmind(
+            message_id="connected_mid",
+            bot_type="submind",
+            service_name="test_service",
+            cid="test_conversation",
+            dom="test_domain",
+            conversation_state=CcaiState.IDLE,
+            responded_shout="test_shout_id",
+            shout="chatbot state",
+            context={"key": "value"},
+            prompt_id="test_prompt_id",
+            omit_reply=False,
+            no_save=False,
+            attached_cids=["cid1", "cid2"],
+            supports_raw_shouts=True,
+            last_ping=current_time
+        )
+        
+        # Create SubmindState objects for testing
+        submind_state1 = {"submind_id": "submind1", "status": SubmindStatus.ACTIVE}
+        submind_state2 = {"submind_id": "submind2", "status": SubmindStatus.BANNED}
+        
+        # Test valid initialization
+        valid_kwargs = {
+            "message_id": "test_message_id",
+            "subminds_per_cid": {
+                "cid1": [submind_state1, submind_state2],
+                "cid2": [submind_state1]
+            },
+            "connected_subminds": {
+                "submind1": connected_submind
+            },
+            "cid_submind_bans": {
+                "cid1": ["banned_submind1"],
+                "cid2": ["banned_submind2", "banned_submind3"]
+            },
+            "banned_subminds": ["globally_banned1", "globally_banned2"]
+        }
+        
+        state = ChatbotsMqSubmindsState(**valid_kwargs)
+        self.assertIsInstance(state, ChatbotsMqSubmindsState)
+        
+        # Test the nested SubmindState objects
+        self.assertEqual(state.subminds_per_cid["cid1"][0].submind_id, "submind1")
+        self.assertEqual(state.subminds_per_cid["cid1"][0].status, SubmindStatus.ACTIVE)
+        self.assertEqual(state.subminds_per_cid["cid1"][1].submind_id, "submind2")
+        self.assertEqual(state.subminds_per_cid["cid1"][1].status, SubmindStatus.BANNED)
+        
+        # Test the connected_subminds mapping
+        self.assertIsInstance(state.connected_subminds["submind1"], ConnectedSubmind)
+        self.assertEqual(state.connected_subminds["submind1"].service_name, "test_service")
+        
+        # Test the ban lists
+        self.assertEqual(state.cid_submind_bans["cid1"], ["banned_submind1"])
+        self.assertEqual(state.cid_submind_bans["cid2"], ["banned_submind2", "banned_submind3"])
+        self.assertEqual(state.banned_subminds, ["globally_banned1", "globally_banned2"])
+        
+        # Test model_dump functionality
+        serialized = state.model_dump()
+        self.assertIn("subminds_per_cid", serialized)
+        self.assertIn("connected_subminds", serialized)
+        self.assertIn("cid_submind_bans", serialized)
+        self.assertIn("banned_subminds", serialized)
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqSubmindsState(
+                message_id="test_message_id"
+                # Missing other required fields
+            )
+

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1281,12 +1281,6 @@ class TestChatbotsMQ(TestCase):
         self.assertIsInstance(serialized["bot_type"], str)
         self.assertEqual(serialized["service_name"], "test_service")
         self.assertEqual(serialized["attached_cids"], ["cid1", "cid2"])
-        
-        # Test missing required fields
-        with self.assertRaises(ValidationError):
-            ConnectedSubmind(
-                message_id="test_message_id",
-                service_name="test_service")
 
         # Test validation logic for deprecated fields
         deprecated_kwargs = valid_kwargs.copy()

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1114,7 +1114,7 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(save_prompt.user_id, "user123")
         self.assertEqual(save_prompt.message_text, "Prompt completed")
         self.assertEqual(save_prompt.prompt_id, "prompt123")
-        self.assertEqual(save_prompt.prompt_text, "Test prompt text")
+        # self.assertEqual(save_prompt.prompt_text, "Test prompt text")
         # self.assertEqual(save_prompt.created_on, "2023-01-01")
         self.assertEqual(save_prompt.context, context)
         

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -794,3 +794,185 @@ class TestNeonMQ(TestCase):
         self.assertEqual(message.data["list_data"][3]["key"], "value")
         self.assertEqual(message.context.client, "test_client")
 
+
+class TestChatbotsMQ(TestCase):
+    def test_chatbot_request(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotRequest
+        from datetime import datetime
+        
+        # Test basic initialization with required fields
+        current_time = datetime.now()
+        valid_kwargs = {
+            "username": "test_user",
+            "cid": "test_conversation",
+            "message_text": "Hello, how are you?",
+            "message_id": "test_message_id",
+            "time_created": current_time
+        }
+        
+        chatbot_request = ChatbotRequest(**valid_kwargs)
+        self.assertIsInstance(chatbot_request, ChatbotRequest)
+        self.assertEqual(chatbot_request.username, "test_user")
+        self.assertEqual(chatbot_request.cid, "test_conversation")
+        self.assertEqual(chatbot_request.message_text, "Hello, how are you?")
+        self.assertEqual(chatbot_request.time_created, current_time)
+        self.assertFalse(chatbot_request.from_bot)  # Default value check
+        
+        # Test with all fields
+        full_kwargs = {
+            "username": "test_user",
+            "cid": "test_conversation",
+            "message_text": "Hello, how are you?",
+            "from_bot": True,
+            "prompt_id": "test_prompt_id",
+            "prompt_state": 1,
+            "time_created": current_time,
+            "requested_participants": ["participant1", "participant2"],
+            "recipient": "test_recipient",
+            "bound_service": "test_service",
+            "client": "test_client",
+            "message_id": "test_message_id",
+            "messageID": "test_sid"
+        }
+        
+        full_request = ChatbotRequest(**full_kwargs)
+        self.assertIsInstance(full_request, ChatbotRequest)
+        self.assertEqual(full_request.username, "test_user")
+        self.assertEqual(full_request.cid, "test_conversation")
+        self.assertEqual(full_request.sid, "test_sid")
+        self.assertEqual(full_request.message_text, "Hello, how are you?")
+        self.assertTrue(full_request.from_bot)
+        self.assertEqual(full_request.prompt_id, "test_prompt_id")
+        self.assertEqual(full_request.prompt_state, 1)
+        self.assertEqual(full_request.time_created, current_time)
+        self.assertEqual(full_request.requested_participants, ["participant1", "participant2"])
+        self.assertEqual(full_request.recipient, "test_recipient")
+        self.assertEqual(full_request.bound_service, "test_service")
+        self.assertEqual(full_request.message_id, "test_message_id")
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotRequest(username="test_user", cid="test_conversation")
+        
+        with self.assertRaises(ValidationError):
+            ChatbotRequest(cid="test_conversation", message_text="Hello", time_created=current_time)
+        
+        with self.assertRaises(ValidationError):
+            ChatbotRequest(username="test_user", message_text="Hello", time_created=current_time)
+        
+        with self.assertRaises(ValidationError):
+            ChatbotRequest(username="test_user", cid="test_conversation", message_text="Hello")
+        
+        # Test model_dump method for backwards compatibility
+        # Test with from_bot=True
+        bot_request = ChatbotRequest(
+            username="test_user",
+            cid="test_conversation",
+            message_id="test_message_id",
+            message_text="Hello from bot",
+            from_bot=True,
+            time_created=datetime.now()
+        )
+        serialized_bot = bot_request.model_dump()
+        self.assertEqual(serialized_bot["bot"], "1")
+        self.assertTrue(serialized_bot["from_bot"])
+        
+        # Test with from_bot=False (default)
+        user_request = ChatbotRequest(
+            username="test_user",
+            cid="test_conversation",
+            message_id="test_message_id",
+            message_text="Hello from user",
+            time_created=datetime.now()
+        )
+        serialized_user = user_request.model_dump()
+        self.assertEqual(serialized_user["bot"], "0")
+        self.assertFalse(serialized_user["from_bot"])
+        
+        # Test with exclude option
+        excluded_data = bot_request.model_dump(exclude={"from_bot"})
+        self.assertEqual(excluded_data["bot"], "1")
+        self.assertNotIn("from_bot", excluded_data)
+        
+        # Test with exclude_none option
+        none_fields_request = ChatbotRequest(
+            username="test_user",
+            cid="test_conversation",
+            message_id="test_message_id",
+            message_text="Testing exclude_none",
+            time_created=datetime.now(),
+            prompt_id=None,
+            recipient=None
+        )
+        serialized_with_none = none_fields_request.model_dump()
+        serialized_without_none = none_fields_request.model_dump(exclude_none=True)
+        
+        self.assertIn("prompt_id", serialized_with_none)
+        self.assertIn("recipient", serialized_with_none)
+        self.assertNotIn("prompt_id", serialized_without_none)
+        self.assertNotIn("recipient", serialized_without_none)
+        self.assertEqual(serialized_without_none["bot"], "0")
+    
+        # Test from_sio_message
+
+        # Create a mock Socket.IO message
+        sio_message = {
+            "userDisplayName": "test_user",
+            "cid": "test_conversation",
+            "messageText": "Hello, how are you?",
+            "bot": 1,  # 1 means it's from a bot
+            "promptId": "test_prompt_id",
+            "promptState": 2,
+            "timeCreated": datetime.now(),
+            "recipient": "test_recipient",
+            "bound_service": "test_service",
+            "client": "test_client",
+            "message_id": "test_message_id"
+        }
+        
+        # Test conversion from Socket.IO message
+        chatbot_request = ChatbotRequest.from_sio_message(sio_message)
+        self.assertIsInstance(chatbot_request, ChatbotRequest)
+        self.assertEqual(chatbot_request.username, "test_user")
+        self.assertEqual(chatbot_request.cid, "test_conversation")
+        self.assertEqual(chatbot_request.message_text, "Hello, how are you?")
+        self.assertTrue(chatbot_request.from_bot)
+        self.assertEqual(chatbot_request.prompt_id, "test_prompt_id")
+        self.assertEqual(chatbot_request.prompt_state, 2)
+        self.assertEqual(chatbot_request.time_created, sio_message["timeCreated"])
+        self.assertEqual(chatbot_request.recipient, "test_recipient")
+        self.assertEqual(chatbot_request.bound_service, "test_service")
+        
+        # Test with bot=0 (from user)
+        sio_message["bot"] = 0
+        chatbot_request = ChatbotRequest.from_sio_message(sio_message)
+        self.assertFalse(chatbot_request.from_bot)
+        
+        # Test with missing optional fields
+        minimal_sio_message = {
+            "userDisplayName": "test_user",
+            "cid": "test_conversation",
+            "message_id": "test_message_id",
+            "messageText": "Hello, how are you?",
+            "timeCreated": datetime.now(),
+        }
+        
+        minimal_request = ChatbotRequest.from_sio_message(minimal_sio_message)
+        self.assertIsInstance(minimal_request, ChatbotRequest)
+        self.assertEqual(minimal_request.username, "test_user")
+        self.assertEqual(minimal_request.cid, "test_conversation")
+        self.assertEqual(minimal_request.message_text, "Hello, how are you?")
+        self.assertFalse(minimal_request.from_bot)
+        self.assertIsNone(minimal_request.prompt_id)
+        self.assertIsNone(minimal_request.prompt_state)
+        self.assertEqual(minimal_request.time_created, minimal_sio_message["timeCreated"])
+        self.assertIsNone(minimal_request.recipient)
+        self.assertIsNone(minimal_request.bound_service)
+        
+        # Test with missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotRequest.from_sio_message({})
+        
+        with self.assertRaises(ValidationError):
+            ChatbotRequest.from_sio_message({"usesrDisplayName": "test_user"})
+

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1392,10 +1392,6 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(serialized["service_name"], "test_service")
         self.assertEqual(serialized["message_id"], "test_message_id")
         
-        # Test missing MQ required data
-        with self.assertRaises(ValidationError):
-            ChatbotsMqConfiguredPersonasRequest(service_name="test_service")
-        
         # Test missing service_name
         with self.assertRaises(ValidationError):
             ChatbotsMqConfiguredPersonasRequest(message_id="test_message_id")
@@ -1545,3 +1541,354 @@ class TestChatbotsMQ(TestCase):
         # Test missing required fields
         with self.assertRaises(ValidationError):
             ChatbotsMqPromptsDataResponse(records=["prompt1", "prompt2"])
+
+    def test_chatbots_mq_submind_response(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqSubmindResponse
+        from datetime import datetime, timezone
+
+        # Test basic initialization with required fields
+        current_time = datetime.now(tz=timezone.utc)
+        valid_kwargs = {
+            "userID": "test_user",
+            "messageText": "Test submind response",
+            "message_id": "test_message_id",
+            "prompt_state": 1,
+        }
+        
+        response = ChatbotsMqSubmindResponse(**valid_kwargs)
+        self.assertIsInstance(response, ChatbotsMqSubmindResponse)
+        self.assertEqual(response.user_id, "test_user")
+        self.assertEqual(response.message_text, "Test submind response")
+        self.assertEqual(response.bot, "0")  # Default value check
+        
+        # Test with all fields including aliased fields
+        full_kwargs = {
+            "userID": "submind1",
+            "userDisplayName": "Test Submind",
+            "messageText": "Full test response",
+            "messageID": "test_shout_id",
+            "repliedMessage": "original_message_id",
+            "bot": "1",
+            "promptID": "prompt_id_123",
+            "conversation_state": 2,
+            "isAnnouncement": True,
+            "timeCreated": current_time,
+            "source": "test_source",
+            "client": "test_client",
+            "cid": "conversation123",
+            "message_id": "test_message_id"
+        }
+        
+        full_response = ChatbotsMqSubmindResponse(**full_kwargs)
+        self.assertIsInstance(full_response, ChatbotsMqSubmindResponse)
+        self.assertEqual(full_response.user_id, "submind1")
+        self.assertEqual(full_response.username, "Test Submind")
+        self.assertEqual(full_response.message_text, "Full test response")
+        self.assertEqual(full_response.sid, "test_shout_id")
+        self.assertEqual(full_response.replied_message, "original_message_id")
+        self.assertEqual(full_response.bot, "1")
+        self.assertEqual(full_response.prompt_id, "prompt_id_123")
+        self.assertEqual(full_response.prompt_state, 2)
+        self.assertTrue(full_response.is_announcement)
+        self.assertEqual(full_response.time_created, current_time)
+        self.assertEqual(full_response.source, "test_source")
+        
+        # Test alternate field names (validate_inputs validator)
+        alternate_kwargs = {
+            "nick": "submind2",
+            "shout": "Message using alternate field names",
+            "responded_shout": "parent_message_id",
+            "time": current_time.timestamp(),
+            "message_id": "test_message_id",
+            "conversation_state": 2,
+        }
+        
+        alternate_response = ChatbotsMqSubmindResponse(**alternate_kwargs)
+        self.assertEqual(alternate_response.user_id, "submind2")
+        self.assertEqual(alternate_response.message_text, "Message using alternate field names")
+        self.assertEqual(alternate_response.replied_message, "parent_message_id")
+        
+        # Test model_dump serialization
+        serialized = full_response.model_dump(by_alias=True)
+        self.assertEqual(serialized["userID"], "submind1")
+        self.assertEqual(serialized["messageText"], "Full test response")
+        self.assertTrue(serialized["isAnnouncement"])
+        self.assertEqual(serialized["nick"], "submind1")  # Check backwards compatibility field
+        self.assertEqual(serialized["shout"], "Full test response")  # Check backwards compatibility field
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqSubmindResponse(messageText="Missing user_id", message_id="test_id")
+        
+        with self.assertRaises(ValidationError):
+            ChatbotsMqSubmindResponse(userID="test_user", message_id="test_id")
+
+    def test_chatbots_mq_response_type_adapter(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqResponse
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqSubmindResponse, ChatbotsMqSavePrompt, ChatbotsMqNewPrompt
+        from neon_data_models.enum import CcaiControl
+        from datetime import datetime, timezone
+        
+        current_time = datetime.now(tz=timezone.utc)
+        
+        # Test regular submind response
+        regular_message = {
+            "userID": "submind1",
+            "messageText": "Regular response",
+            "conversation_state": 2,
+            "message_id": "test_message_id"
+        }
+        
+        result = ChatbotsMqResponse(**regular_message)
+        self.assertIsInstance(result, ChatbotsMqSubmindResponse)
+        self.assertEqual(result.user_id, "submind1")
+        self.assertEqual(result.message_text, "Regular response")
+        
+        # Test save prompt message
+        save_prompt_message = {
+            "userID": "submind1",
+            "messageText": CcaiControl.SAVE_PROMPT_RESULTS,
+            "prompt_id": "prompt_123",
+            "prompt_text": "Test prompt",
+            "created_on": "2023-01-01",
+            "message_id": "test_message_id",
+            "conversation_state": 0,
+            "conversation_context": {
+                "prompt": {
+                    "username": "test_user",
+                    "cid": "test_conversation",
+                    "message_text": "Original prompt",
+                    "message_id": "original_message_id",
+                    "time_created": current_time
+                },
+                "is_active": False,
+                "prompt_text": "Original prompt",
+                "available_subminds": ["submind1", "submind2"],
+                "state": 2,
+                "participating_subminds": ["submind1"],
+                "proposed_responses": {"submind1": "Response 1"},
+                "submind_opinions": {"submind1": "Opinion 1"},
+                "votes": {"submind1": "vote1"},
+                "votes_per_submind": {"submind1": ["vote1"]},
+                "winner": "submind1"
+            }
+        }
+        
+        result = ChatbotsMqResponse(**save_prompt_message)
+        self.assertIsInstance(result, ChatbotsMqSavePrompt)
+        self.assertEqual(result.prompt_id, "prompt_123")
+        self.assertEqual(result.prompt_text, "Test prompt")
+        self.assertEqual(result.created_on, "2023-01-01")
+        self.assertEqual(result.context.winner, "submind1")
+        
+        # Test new prompt message
+        new_prompt_message = {
+            "userID": "submind1",
+            "messageText": CcaiControl.CREATE_PROMPT,
+            "prompt_id": "prompt_456",
+            "prompt_text": "New test prompt",
+            "conversation_state": 2,
+            "message_id": "test_message_id"
+        }
+        
+        result = ChatbotsMqResponse(**new_prompt_message)
+        self.assertIsInstance(result, ChatbotsMqNewPrompt)
+        self.assertEqual(result.prompt_id, "prompt_456")
+        self.assertEqual(result.prompt_text, "New test prompt")
+        
+        # Test with message_text vs messageText
+        alternate_syntax = {
+            "userID": "submind1",
+            "message_text": "Using message_text instead of messageText",
+            "conversation_state": 2,
+            "message_id": "test_message_id"
+        }
+        
+        result = ChatbotsMqResponse(**alternate_syntax)
+        self.assertIsInstance(result, ChatbotsMqSubmindResponse)
+        self.assertEqual(result.message_text, "Using message_text instead of messageText")
+
+    def test_chatbots_mq_submind_connection(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqSubmindConnection
+        from datetime import datetime, timezone
+        
+        # Test basic initialization
+        current_time = datetime.now(tz=timezone.utc)
+        valid_kwargs = {
+            "nick": "submind1",
+            "time": current_time,
+            "message_id": "test_message_id"
+        }
+        
+        connection = ChatbotsMqSubmindConnection(**valid_kwargs)
+        self.assertIsInstance(connection, ChatbotsMqSubmindConnection)
+        self.assertEqual(connection.user_id, "submind1")  # Check aliased field
+        self.assertEqual(connection.time, current_time)
+        self.assertFalse(connection.supports_raw_shouts)  # Default value
+        
+        # Test with all fields
+        full_kwargs = {
+            "user_id": "submind2",
+            "time": current_time,
+            "cids": ["conversation1", "conversation2"],
+            "supports_raw_shouts": True,
+            "message_id": "test_message_id"
+        }
+        
+        full_connection = ChatbotsMqSubmindConnection(**full_kwargs)
+        self.assertEqual(full_connection.user_id, "submind2")
+        self.assertEqual(full_connection.cids, ["conversation1", "conversation2"])
+        self.assertTrue(full_connection.supports_raw_shouts)
+        
+        # # Test alias interchangeability (populate_by_name config)
+        # self.assertEqual(full_connection.user_id, full_connection.nick)
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqSubmindConnection(time=current_time, message_id="test_id")
+        
+        with self.assertRaises(ValidationError):
+            ChatbotsMqSubmindConnection(user_id="submind1", time=current_time,
+                                        cids="invalid_type")
+
+    def test_chatbots_mq_submind_disconnection(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqSubmindDisconnection
+        
+        # Test basic initialization
+        valid_kwargs = {
+            "nick": "submind1",
+            "message_id": "test_message_id"
+        }
+        
+        disconnection = ChatbotsMqSubmindDisconnection(**valid_kwargs)
+        self.assertIsInstance(disconnection, ChatbotsMqSubmindDisconnection)
+        self.assertEqual(disconnection.user_id, "submind1")  # Check aliased field
+        
+        # Test with user_id instead of nick
+        alternate_kwargs = {
+            "user_id": "submind2",
+            "message_id": "test_message_id"
+        }
+        
+        alternate_disconnection = ChatbotsMqSubmindDisconnection(**alternate_kwargs)
+        self.assertEqual(alternate_disconnection.user_id, "submind2")
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqSubmindDisconnection(message_id="test_id")
+
+    def test_chatbots_mq_submind_invitation(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqSubmindInvitation
+        
+        # Test basic initialization
+        valid_kwargs = {
+            "cid": "conversation123",
+            "requested_participants": ["submind1", "submind2"],
+            "message_id": "test_message_id"
+        }
+        
+        invitation = ChatbotsMqSubmindInvitation(**valid_kwargs)
+        self.assertIsInstance(invitation, ChatbotsMqSubmindInvitation)
+        self.assertEqual(invitation.cid, "conversation123")
+        self.assertEqual(invitation.requested_participants, ["submind1", "submind2"])
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqSubmindInvitation(cid="conversation123", message_id="test_id")
+        
+        with self.assertRaises(ValidationError):
+            ChatbotsMqSubmindInvitation(requested_participants=["submind1"], message_id="test_id")
+
+    def test_chatbots_mq_update_participating_subminds(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqUpdateParticipatingSubminds
+        
+        # Test basic initialization with required fields
+        valid_kwargs = {
+            "cid": "conversation123",
+            "message_id": "test_message_id"
+        }
+        
+        update = ChatbotsMqUpdateParticipatingSubminds(**valid_kwargs)
+        self.assertIsInstance(update, ChatbotsMqUpdateParticipatingSubminds)
+        self.assertEqual(update.cid, "conversation123")
+        self.assertEqual(update.subminds_to_invite, [])  # Default value
+        self.assertEqual(update.subminds_to_kick, [])  # Default value
+        
+        # Test with all fields
+        full_kwargs = {
+            "cid": "conversation123",
+            "subminds_to_invite": ["new_submind1", "new_submind2"],
+            "subminds_to_kick": ["old_submind1"],
+            "message_id": "test_message_id"
+        }
+        
+        full_update = ChatbotsMqUpdateParticipatingSubminds(**full_kwargs)
+        self.assertEqual(full_update.subminds_to_invite, ["new_submind1", "new_submind2"])
+        self.assertEqual(full_update.subminds_to_kick, ["old_submind1"])
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqUpdateParticipatingSubminds(subminds_to_invite=["submind1"], message_id="test_id")
+        
+        # TODO: Should this raise an exception if the request does nothing?
+        # with self.assertRaises(ValidationError):
+        #     ChatbotsMqUpdateParticipatingSubminds(cid="conversation123")
+
+    def test_chatbots_mq_submind_conversation_ban(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqSubmindConversationBan
+        
+        # Test basic initialization
+        valid_kwargs = {
+            "nick": "submind1",
+            "cid": "conversation123",
+            "message_id": "test_message_id"
+        }
+        
+        ban = ChatbotsMqSubmindConversationBan(**valid_kwargs)
+        self.assertIsInstance(ban, ChatbotsMqSubmindConversationBan)
+        self.assertEqual(ban.user_id, "submind1")  # Check aliased field
+        self.assertEqual(ban.cid, "conversation123")
+        
+        # Test with user_id instead of nick
+        alternate_kwargs = {
+            "user_id": "submind2",
+            "cid": "conversation456",
+            "message_id": "test_message_id"
+        }
+        
+        alternate_ban = ChatbotsMqSubmindConversationBan(**alternate_kwargs)
+        self.assertEqual(alternate_ban.user_id, "submind2")
+        self.assertEqual(alternate_ban.cid, "conversation456")
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqSubmindConversationBan(user_id="submind1", message_id="test_id")
+        
+        with self.assertRaises(ValidationError):
+            ChatbotsMqSubmindConversationBan(cid="conversation123", message_id="test_id")
+
+    def test_chatbots_mq_submind_global_ban(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqSubmindGlobalBan
+        
+        # Test basic initialization
+        valid_kwargs = {
+            "nick": "submind1",
+            "message_id": "test_message_id"
+        }
+        
+        ban = ChatbotsMqSubmindGlobalBan(**valid_kwargs)
+        self.assertIsInstance(ban, ChatbotsMqSubmindGlobalBan)
+        self.assertEqual(ban.user_id, "submind1")  # Check aliased field
+        
+        # Test with user_id instead of nick
+        alternate_kwargs = {
+            "user_id": "submind2",
+            "message_id": "test_message_id"
+        }
+        
+        alternate_ban = ChatbotsMqSubmindGlobalBan(**alternate_kwargs)
+        self.assertEqual(alternate_ban.user_id, "submind2")
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqSubmindGlobalBan(message_id="test_id")

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1669,7 +1669,6 @@ class TestChatbotsMQ(TestCase):
             "omit_reply": True,
             "no_save": False,
             "created_on": 1743531762,
-            "to_discussion": None
         }
 
         alt_new_prompt_message = {
@@ -1722,14 +1721,11 @@ class TestChatbotsMQ(TestCase):
             "service_name": "proctor",
             "context": {
                 "winner": "submind1",
-                "prompt_text": "Test prompt",
-                # "created_on": "2023-01-01"
+                "prompt_text": "Test prompt"
             },
             "dom": "",
             "omit_reply": True,
-            "no_save": False,
-            # "created_on": None,
-            "to_discussion": None
+            "no_save": False
         }
         alt_save_prompt_message = {
             "nick": "proctor-ac18f03d0937490080c798d3b242ecd0",

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1264,7 +1264,7 @@ class TestChatbotsMQ(TestCase):
             "omit_reply": False,
             "no_save": False,
             "attached_cids": ["cid1", "cid2"],
-            "supports_raw_shouts": True,
+            "supports_raw_conversation": True,
             "last_ping": current_time
         }
         
@@ -1274,7 +1274,7 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(submind.service_name, "test_service")
         self.assertEqual(submind.attached_cids, ["cid1", "cid2"])
         self.assertEqual(submind.last_ping, current_time)
-        self.assertTrue(submind.supports_raw_shouts)
+        self.assertTrue(submind.supports_raw_conversation)
         
         # Test model_dump functionality
         serialized = submind.model_dump()
@@ -1318,7 +1318,7 @@ class TestChatbotsMQ(TestCase):
             omit_reply=False,
             no_save=False,
             attached_cids=["cid1", "cid2"],
-            supports_raw_shouts=True,
+            supports_raw_conversation=True,
             last_ping=current_time
         )
         
@@ -1848,21 +1848,21 @@ class TestChatbotsMQ(TestCase):
         self.assertIsInstance(connection, ChatbotsMqSubmindConnection)
         self.assertEqual(connection.user_id, "submind1")  # Check aliased field
         self.assertEqual(connection.time, current_time)
-        self.assertFalse(connection.supports_raw_shouts)  # Default value
+        self.assertFalse(connection.supports_raw_conversation)  # Default value
         
         # Test with all fields
         full_kwargs = {
             "user_id": "submind2",
             "time": current_time,
             "cids": ["conversation1", "conversation2"],
-            "supports_raw_shouts": True,
+            "supports_raw_conversation": True,
             "message_id": "test_message_id"
         }
         
         full_connection = ChatbotsMqSubmindConnection(**full_kwargs)
         self.assertEqual(full_connection.user_id, "submind2")
         self.assertEqual(full_connection.cids, ["conversation1", "conversation2"])
-        self.assertTrue(full_connection.supports_raw_shouts)
+        self.assertTrue(full_connection.supports_raw_conversation)
         
         # # Test alias interchangeability (populate_by_name config)
         # self.assertEqual(full_connection.user_id, full_connection.nick)

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -26,6 +26,7 @@
 
 from unittest import TestCase
 from pydantic import ValidationError
+from datetime import datetime, timezone
 
 
 class TestUsersMQ(TestCase):
@@ -796,12 +797,11 @@ class TestNeonMQ(TestCase):
 
 
 class TestChatbotsMQ(TestCase):
-    def test_chatbot_request(self):
-        from neon_data_models.models.api.mq.chatbots import ChatbotRequest
-        from datetime import datetime
+    def test_chatbots_mq_request(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqRequest
         
         # Test basic initialization with required fields
-        current_time = datetime.now()
+        current_time = datetime.now(tz=timezone.utc)
         valid_kwargs = {
             "username": "test_user",
             "cid": "test_conversation",
@@ -810,8 +810,8 @@ class TestChatbotsMQ(TestCase):
             "time_created": current_time
         }
         
-        chatbot_request = ChatbotRequest(**valid_kwargs)
-        self.assertIsInstance(chatbot_request, ChatbotRequest)
+        chatbot_request = ChatbotsMqRequest(**valid_kwargs)
+        self.assertIsInstance(chatbot_request, ChatbotsMqRequest)
         self.assertEqual(chatbot_request.username, "test_user")
         self.assertEqual(chatbot_request.cid, "test_conversation")
         self.assertEqual(chatbot_request.message_text, "Hello, how are you?")
@@ -835,8 +835,8 @@ class TestChatbotsMQ(TestCase):
             "messageID": "test_sid"
         }
         
-        full_request = ChatbotRequest(**full_kwargs)
-        self.assertIsInstance(full_request, ChatbotRequest)
+        full_request = ChatbotsMqRequest(**full_kwargs)
+        self.assertIsInstance(full_request, ChatbotsMqRequest)
         self.assertEqual(full_request.username, "test_user")
         self.assertEqual(full_request.cid, "test_conversation")
         self.assertEqual(full_request.sid, "test_sid")
@@ -852,163 +852,87 @@ class TestChatbotsMQ(TestCase):
         
         # Test missing required fields
         with self.assertRaises(ValidationError):
-            ChatbotRequest(username="test_user", cid="test_conversation")
+            # Missing message text
+            ChatbotsMqRequest(username="test_user", cid="test_conversation")
         
         with self.assertRaises(ValidationError):
-            ChatbotRequest(cid="test_conversation", message_text="Hello", time_created=current_time)
+            # Missing username
+            ChatbotsMqRequest(cid="test_conversation", message_text="Hello", 
+                              time_created=current_time)
         
         with self.assertRaises(ValidationError):
-            ChatbotRequest(username="test_user", message_text="Hello", time_created=current_time)
-        
-        with self.assertRaises(ValidationError):
-            ChatbotRequest(username="test_user", cid="test_conversation", message_text="Hello")
+            # Missing cid
+            ChatbotsMqRequest(username="test_user", message_text="Hello", time_created=current_time)
         
         # Test model_dump method for backwards compatibility
         # Test with from_bot=True
-        bot_request = ChatbotRequest(
+        bot_request = ChatbotsMqRequest(
             username="test_user",
             cid="test_conversation",
             message_id="test_message_id",
             message_text="Hello from bot",
             from_bot=True,
-            time_created=datetime.now()
+            time_created=datetime.now(tz=timezone.utc)
         )
         serialized_bot = bot_request.model_dump()
         self.assertEqual(serialized_bot["bot"], "1")
         self.assertTrue(serialized_bot["from_bot"])
+        self.assertEqual(serialized_bot["messageText"], bot_request.message_text)
+        self.assertEqual(serialized_bot["nick"], bot_request.username)
         
         # Test with from_bot=False (default)
-        user_request = ChatbotRequest(
+        user_request = ChatbotsMqRequest(
             username="test_user",
             cid="test_conversation",
             message_id="test_message_id",
             message_text="Hello from user",
-            time_created=datetime.now()
+            time_created=datetime.now(tz=timezone.utc)
         )
         serialized_user = user_request.model_dump()
         self.assertEqual(serialized_user["bot"], "0")
         self.assertFalse(serialized_user["from_bot"])
         
-        # Test with exclude option
-        excluded_data = bot_request.model_dump(exclude={"from_bot"})
-        self.assertEqual(excluded_data["bot"], "1")
-        self.assertNotIn("from_bot", excluded_data)
-        
-        # Test with exclude_none option
-        none_fields_request = ChatbotRequest(
-            username="test_user",
-            cid="test_conversation",
-            message_id="test_message_id",
-            message_text="Testing exclude_none",
-            time_created=datetime.now(),
-            prompt_id=None,
-            recipient=None
-        )
-        serialized_with_none = none_fields_request.model_dump()
-        serialized_without_none = none_fields_request.model_dump(exclude_none=True)
-        
-        self.assertIn("prompt_id", serialized_with_none)
-        self.assertIn("recipient", serialized_with_none)
-        self.assertNotIn("prompt_id", serialized_without_none)
-        self.assertNotIn("recipient", serialized_without_none)
-        self.assertEqual(serialized_without_none["bot"], "0")
-    
-        # Test from_sio_message
-
-        # Create a mock Socket.IO message
+        # Test from_sio_message method
         sio_message = {
-            "userDisplayName": "test_user",
-            "cid": "test_conversation",
-            "messageText": "Hello, how are you?",
-            "bot": 1,  # 1 means it's from a bot
-            "promptId": "test_prompt_id",
-            "promptState": 2,
-            "timeCreated": datetime.now(),
-            "recipient": "test_recipient",
-            "bound_service": "test_service",
-            "client": "test_client",
-            "message_id": "test_message_id"
-        }
-        
-        # Test conversion from Socket.IO message
-        chatbot_request = ChatbotRequest.from_sio_message(sio_message)
-        self.assertIsInstance(chatbot_request, ChatbotRequest)
-        self.assertEqual(chatbot_request.username, "test_user")
-        self.assertEqual(chatbot_request.cid, "test_conversation")
-        self.assertEqual(chatbot_request.message_text, "Hello, how are you?")
-        self.assertTrue(chatbot_request.from_bot)
-        self.assertEqual(chatbot_request.prompt_id, "test_prompt_id")
-        self.assertEqual(chatbot_request.prompt_state, 2)
-        self.assertEqual(chatbot_request.time_created, sio_message["timeCreated"])
-        self.assertEqual(chatbot_request.recipient, "test_recipient")
-        self.assertEqual(chatbot_request.bound_service, "test_service")
-        
-        # Test with bot=0 (from user)
-        sio_message["bot"] = 0
-        chatbot_request = ChatbotRequest.from_sio_message(sio_message)
-        self.assertFalse(chatbot_request.from_bot)
-        
-        # Test with missing optional fields
-        minimal_sio_message = {
-            "userDisplayName": "test_user",
-            "cid": "test_conversation",
-            "message_id": "test_message_id",
-            "messageText": "Hello, how are you?",
-            "timeCreated": datetime.now(),
-        }
-        
-        minimal_request = ChatbotRequest.from_sio_message(minimal_sio_message)
-        self.assertIsInstance(minimal_request, ChatbotRequest)
-        self.assertEqual(minimal_request.username, "test_user")
-        self.assertEqual(minimal_request.cid, "test_conversation")
-        self.assertEqual(minimal_request.message_text, "Hello, how are you?")
-        self.assertFalse(minimal_request.from_bot)
-        self.assertIsNone(minimal_request.prompt_id)
-        self.assertIsNone(minimal_request.prompt_state)
-        self.assertEqual(minimal_request.time_created, minimal_sio_message["timeCreated"])
-        self.assertIsNone(minimal_request.recipient)
-        self.assertIsNone(minimal_request.bound_service)
-        
-        # Test with missing required fields
-        with self.assertRaises(ValidationError):
-            ChatbotRequest.from_sio_message({})
-        
-        with self.assertRaises(ValidationError):
-            ChatbotRequest.from_sio_message({"usesrDisplayName": "test_user"})
-        
-        # Test with userID fallback when userDisplayName is not present
-        user_id_sio_message = {
-            "userID": "test_user_id",
-            "cid": "test_conversation",
-            "messageText": "Hello, how are you?",
-            "timeCreated": datetime.now(),
-            "message_id": "test_message_id"
-        }
-        
-        user_id_request = ChatbotRequest.from_sio_message(user_id_sio_message)
-        self.assertIsInstance(user_id_request, ChatbotRequest)
-        self.assertEqual(user_id_request.username, "test_user_id")
-        self.assertEqual(user_id_request.cid, "test_conversation")
-        self.assertEqual(user_id_request.message_text, "Hello, how are you?")
-        
-        # Test with both userDisplayName and userID (userDisplayName should be preferred)
-        both_names_sio_message = {
             "userDisplayName": "display_name",
             "userID": "user_id",
             "cid": "test_conversation",
-            "messageText": "Hello, how are you?",
-            "timeCreated": datetime.now(),
+            "messageText": "Hello from SIO",
+            "bot": 1,
+            "promptID": "test_prompt_id",
+            "promptState": 2,
+            "timeCreated": current_time,
+            "recipient": "chatbots",
+            "bound_service": "test_service",
             "message_id": "test_message_id"
         }
         
-        both_names_request = ChatbotRequest.from_sio_message(both_names_sio_message)
-        self.assertIsInstance(both_names_request, ChatbotRequest)
-        self.assertEqual(both_names_request.username, "display_name")
-        self.assertEqual(both_names_request.cid, "test_conversation")
-        self.assertEqual(both_names_request.message_text, "Hello, how are you?")
-    
-    def test_chatbot_response(self):
-        from neon_data_models.models.api.mq.chatbots import ChatbotResponse
+        sio_request = ChatbotsMqRequest.from_sio_message(sio_message)
+        self.assertIsInstance(sio_request, ChatbotsMqRequest)
+        self.assertEqual(sio_request.username, "display_name")
+        self.assertEqual(sio_request.cid, "test_conversation")
+        self.assertEqual(sio_request.message_text, "Hello from SIO")
+        self.assertTrue(sio_request.from_bot)
+        self.assertEqual(sio_request.prompt_id, "test_prompt_id")
+        self.assertEqual(sio_request.prompt_state, 2)
+        self.assertEqual(sio_request.time_created, current_time)
+        self.assertEqual(sio_request.recipient, "chatbots")
+        self.assertEqual(sio_request.bound_service, "test_service")
+        
+        # Test userID fallback
+        sio_message = {
+            "userID": "user_id",
+            "cid": "test_conversation",
+            "messageText": "Hello from SIO",
+            "timeCreated": current_time,
+            "message_id": "test_message_id"
+        }
+        
+        sio_request = ChatbotsMqRequest.from_sio_message(sio_message)
+        self.assertEqual(sio_request.username, "user_id")
+
+    def test_chatbots_mq_response(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqResponse
         from datetime import datetime, timezone
         
         # Test basic initialization with required fields
@@ -1016,17 +940,17 @@ class TestChatbotsMQ(TestCase):
         valid_kwargs = {
             "userID": "user123",
             "messageText": "Hello, this is a response",
-            "message_id": "test_message_id"  # Added required message_id
+            "message_id": "test_message_id"
         }
         
-        response = ChatbotResponse(**valid_kwargs)
-        self.assertIsInstance(response, ChatbotResponse)
+        response = ChatbotsMqResponse(**valid_kwargs)
+        self.assertIsInstance(response, ChatbotsMqResponse)
         self.assertEqual(response.user_id, "user123")
         self.assertEqual(response.message_text, "Hello, this is a response")
         self.assertEqual(response.bot, "0")  # Default value check
         self.assertEqual(response.is_announcement, "0")  # Default value check
         
-        # Test with all fields
+        # Test with all fields including aliases
         full_kwargs = {
             "userID": "user123",
             "userDisplayName": "John Doe",
@@ -1044,8 +968,8 @@ class TestChatbotsMQ(TestCase):
             "message_id": "message123"
         }
         
-        full_response = ChatbotResponse(**full_kwargs)
-        self.assertIsInstance(full_response, ChatbotResponse)
+        full_response = ChatbotsMqResponse(**full_kwargs)
+        self.assertIsInstance(full_response, ChatbotsMqResponse)
         self.assertEqual(full_response.user_id, "user123")
         self.assertEqual(full_response.username, "John Doe")
         self.assertEqual(full_response.message_text, "Hello, this is a complete response")
@@ -1060,70 +984,262 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(full_response.cid, "conversation123")
         self.assertEqual(full_response.message_id, "message123")
         
-        # Test with default time_created
-        response_with_default_time = ChatbotResponse(
-            userID="user456",
-            messageText="Response with default time",
-            message_id="test_mid_default_time"  # Added required message_id
-        )
-        self.assertIsInstance(response_with_default_time.time_created, datetime)
+        # Test model_dump with aliased fields
+        serialized = full_response.model_dump()
+        self.assertIn("userID", serialized)
+        self.assertIn("userDisplayName", serialized)
+        self.assertIn("messageText", serialized)
+        self.assertIn("messageID", serialized)
+        self.assertIn("repliedMessage", serialized)
+        self.assertIn("promptID", serialized)
+        self.assertIn("isAnnouncement", serialized)
+        self.assertIn("timeCreated", serialized)
         
-        # Test field aliases
-        aliased_data = {
-            "userID": "user123",
-            "userDisplayName": "John Doe",
-            "messageText": "Testing aliases",
-            "messageID": "alias_msg_id",
-            "promptID": "alias_prompt_id",
-            "message_id": "test_mid_aliases"  # Added required message_id
+        # Test invalid literal values
+        with self.assertRaises(ValidationError):
+            ChatbotsMqResponse(
+                userID="user123",
+                messageText="Test",
+                bot="2",  # Invalid value, only "0" or "1" allowed
+                message_id="test_id"
+            )
+            
+        with self.assertRaises(ValidationError):
+            ChatbotsMqResponse(
+                userID="user123",
+                messageText="Test",
+                isAnnouncement="2",  # Invalid value, only "0" or "1" allowed
+                message_id="test_id"
+            )
+
+    def test_prompt_completed_context(self):
+        from neon_data_models.models.api.mq.chatbots import PromptCompletedContext, ChatbotsMqRequest
+        from datetime import datetime, timezone
+        
+        # Create a test ChatbotsMqRequest for the prompt field
+        request = ChatbotsMqRequest(
+            username="test_user",
+            cid="test_conversation",
+            message_text="Test prompt",
+            message_id="test_message_id",
+            time_created=datetime.now(tz=timezone.utc)
+        )
+        
+        # Test initialization with required fields
+        valid_kwargs = {
+            "prompt": request,
+            "is_active": True,
+            "prompt_text": "Test prompt text",
+            "available_subminds": ["submind1", "submind2"],
+            "state": 1,
+            "participating_subminds": ["submind1"],
+            "proposed_responses": {"submind1": "Response 1"},
+            "submind_opinions": {"submind1": "Opinion 1"},
+            "votes": {"submind1": "vote1"},
+            "votes_per_submind": {"submind1": ["vote1"]}
         }
         
-        aliased_response = ChatbotResponse(**aliased_data)
-        self.assertEqual(aliased_response.user_id, "user123")
-        self.assertEqual(aliased_response.username, "John Doe")
-        self.assertEqual(aliased_response.message_text, "Testing aliases")
-        self.assertEqual(aliased_response.sid, "alias_msg_id")
-        self.assertEqual(aliased_response.prompt_id, "alias_prompt_id")
+        context = PromptCompletedContext(**valid_kwargs)
+        self.assertIsInstance(context, PromptCompletedContext)
+        self.assertEqual(context.prompt, request)
+        self.assertTrue(context.is_active)
+        self.assertEqual(context.prompt_text, "Test prompt text")
+        self.assertEqual(context.available_subminds, ["submind1", "submind2"])
+        self.assertEqual(context.state, 1)
+        self.assertEqual(context.participating_subminds, ["submind1"])
+        self.assertEqual(context.proposed_responses, {"submind1": "Response 1"})
+        self.assertEqual(context.submind_opinions, {"submind1": "Opinion 1"})
+        self.assertEqual(context.votes, {"submind1": "vote1"})
+        self.assertEqual(context.votes_per_submind, {"submind1": ["vote1"]})
+        self.assertEqual(context.winner, "")  # Default value
         
-        # Test invalid bot value
-        with self.assertRaises(ValidationError):
-            ChatbotResponse(userID="user123", messageText="Test", bot="2", 
-                           message_id="test_mid_invalid_bot")  # Added required message_id
-            
-        # Test invalid is_announcement value
-        with self.assertRaises(ValidationError):
-            ChatbotResponse(userID="user123", messageText="Test", isAnnouncement="2",
-                           message_id="test_mid_invalid_announcement")  # Added required message_id
-            
+        # Test with winner field
+        context_with_winner = PromptCompletedContext(
+            **valid_kwargs,
+            winner="submind1"
+        )
+        self.assertEqual(context_with_winner.winner, "submind1")
+        
         # Test missing required fields
         with self.assertRaises(ValidationError):
-            ChatbotResponse(userDisplayName="John Doe", message_id="test_mid_missing_userID")
-            
-        with self.assertRaises(ValidationError):
-            ChatbotResponse(userID="user123", message_id="test_mid_missing_messageText")
-            
-        with self.assertRaises(ValidationError):
-            ChatbotResponse(userID="user123", messageText="Missing message_id")
-            
-        # Test model serialization with exclude_none
-        response_with_none = ChatbotResponse(
-            userID="user123",
-            messageText="Test exclude_none",
-            username=None,
-            promptID=None,
-            message_id="test_mid_exclude_none"  # Added required message_id
+            PromptCompletedContext(
+                is_active=True,
+                prompt_text="Test prompt text",
+                available_subminds=["submind1", "submind2"],
+                state=1,
+                participating_subminds=["submind1"],
+                proposed_responses={"submind1": "Response 1"},
+                submind_opinions={"submind1": "Opinion 1"},
+                votes={"submind1": "vote1"},
+                votes_per_submind={"submind1": ["vote1"]}
+            )
+
+    def test_chatbots_mq_save_prompt(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqSavePrompt, PromptCompletedContext, ChatbotsMqRequest
+        from datetime import datetime, timezone
+        
+        # Create necessary components for testing
+        request = ChatbotsMqRequest(
+            username="test_user",
+            cid="test_conversation",
+            message_text="Test prompt",
+            message_id="test_message_id",
+            time_created=datetime.now(tz=timezone.utc)
         )
-        serialized_with_none = response_with_none.model_dump()
-        serialized_without_none = response_with_none.model_dump()
         
-        # Fix: Check for attribute names, not alias names in serialized output
-        self.assertIn("userDisplayName", serialized_with_none)
-        self.assertIn("promptID", serialized_with_none)
-        # self.assertNotIn("userDisplayName", serialized_without_none)
-        # self.assertNotIn("promptID", serialized_without_none)
+        context = PromptCompletedContext(
+            prompt=request,
+            is_active=False,
+            prompt_text="Test prompt text",
+            available_subminds=["submind1", "submind2"],
+            state=2,
+            participating_subminds=["submind1"],
+            proposed_responses={"submind1": "Response 1"},
+            submind_opinions={"submind1": "Opinion 1"},
+            votes={"submind1": "vote1"},
+            votes_per_submind={"submind1": ["vote1"]},
+            winner="submind1"
+        )
         
-        # Test model serialization with by_alias=True to get the field aliases instead
-        serialized_with_alias = response_with_none.model_dump()
-        self.assertIn("userDisplayName", serialized_with_alias)
-        self.assertIn("promptID", serialized_with_alias)
+        # Test initialization
+        valid_kwargs = {
+            "userID": "user123",
+            "messageText": "Prompt completed",
+            "message_id": "test_message_id",
+            "prompt_id": "prompt123",
+            "prompt_text": "Test prompt text",
+            "created_on": "2023-01-01",
+            "context": context
+        }
+        
+        save_prompt = ChatbotsMqSavePrompt(**valid_kwargs)
+        self.assertIsInstance(save_prompt, ChatbotsMqSavePrompt)
+        self.assertEqual(save_prompt.user_id, "user123")
+        self.assertEqual(save_prompt.message_text, "Prompt completed")
+        self.assertEqual(save_prompt.prompt_id, "prompt123")
+        self.assertEqual(save_prompt.prompt_text, "Test prompt text")
+        self.assertEqual(save_prompt.created_on, "2023-01-01")
+        self.assertEqual(save_prompt.context, context)
+        
+        # Test model_dump inheritance from ChatbotsMqResponse
+        serialized = save_prompt.model_dump()
+        self.assertIn("userID", serialized)
+        self.assertIn("messageText", serialized)
+        self.assertIn("prompt_id", serialized)
+        self.assertIn("context", serialized)
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqSavePrompt(
+                userID="user123",
+                messageText="Prompt completed",
+                message_id="test_message_id",
+                prompt_id="prompt123",
+                prompt_text="Test prompt text",
+                created_on="2023-01-01"
+                # Missing context
+            )
+
+    def test_chatbots_mq_new_prompt(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqNewPrompt
+        from datetime import datetime, timezone
+        
+        # Test initialization with required fields
+        valid_kwargs = {
+            "user_id": "user123",
+            "messageText": "New prompt",
+            "message_id": "test_message_id",
+            "prompt_id": "prompt123",
+            "prompt_text": "Test prompt text"
+        }
+        
+        new_prompt = ChatbotsMqNewPrompt(**valid_kwargs)
+        self.assertIsInstance(new_prompt, ChatbotsMqNewPrompt)
+        self.assertEqual(new_prompt.user_id, "user123")
+        self.assertEqual(new_prompt.message_text, "Test prompt text")
+        self.assertEqual(new_prompt.prompt_id, "prompt123")
+        self.assertEqual(new_prompt.prompt_text, "Test prompt text")
+        self.assertIsNone(new_prompt.context)
+        
+        # Test with conversation_context alias
+        context_kwargs = {
+            "user_id": "user123",
+            "messageText": "New prompt with context",
+            "message_id": "test_message_id",
+            "prompt_id": "prompt123",
+            "prompt_text": "Test prompt text",
+            "conversation_context": {"some_key": "some_value"}
+        }
+        
+        context_prompt = ChatbotsMqNewPrompt(**context_kwargs)
+        self.assertEqual(context_prompt.context, {"some_key": "some_value"})
+        
+        # Test model validator
+        # Create a message with prompt_text but no messageText
+        partial_kwargs = {
+            "user_id": "user123",
+            "message_id": "test_message_id",
+            "prompt_id": "prompt123",
+            "prompt_text": "Only prompt text"
+        }
+        
+        partial_prompt = ChatbotsMqNewPrompt(**partial_kwargs)
+        self.assertEqual(partial_prompt.message_text, "Only prompt text")
+        
+        # Test model_dump inheritance from ChatbotsMqResponse
+        serialized = new_prompt.model_dump()
+        self.assertIn("user_id", serialized)
+        self.assertIn("messageText", serialized)
+        self.assertIn("prompt_id", serialized)
+        
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqNewPrompt(
+                user_id="user123",
+                messageText="New prompt",
+                message_id="test_message_id"
+                # Missing prompt_id
+            )
+            
+        with self.assertRaises(ValidationError):
+            ChatbotsMqNewPrompt(
+                user_id="user123",
+                message_id="test_message_id",
+                prompt_id="prompt123"
+                # Missing messageText or prompt_text
+            )
+
+    def test_old_class_names_compatibility(self):
+        """Test backward compatibility with old class names"""
+        import neon_data_models.models.api.mq.chatbots as chatbots_module
+        
+        # Check if the old class names are still available through __all__
+        self.assertIn("ChatbotsMqRequest", chatbots_module.__all__)
+        self.assertIn("ChatbotsMqResponse", chatbots_module.__all__)
+        self.assertIn("ChatbotsMqSavePrompt", chatbots_module.__all__)
+        self.assertIn("ChatbotsMqNewPrompt", chatbots_module.__all__)
+        
+        # Import the actual classes to verify they exist
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqRequest, ChatbotsMqResponse
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqSavePrompt, ChatbotsMqNewPrompt
+        
+        # Test instantiation with basic properties
+        req = ChatbotsMqRequest(
+            username="test_user",
+            cid="test_conversation",
+            message_text="Test message",
+            message_id="test_message_id",
+            time_created=datetime.now(timezone.utc)
+        )
+        self.assertIsInstance(req, ChatbotsMqRequest)
+        
+        resp = ChatbotsMqResponse(
+            userID="test_user",
+            messageText="Test response",
+            message_id="test_message_id"
+        )
+        self.assertIsInstance(resp, ChatbotsMqResponse)
+        
+        # These tests verify that the classes are properly defined and usable
+        # even with the new names
 

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -975,4 +975,35 @@ class TestChatbotsMQ(TestCase):
         
         with self.assertRaises(ValidationError):
             ChatbotRequest.from_sio_message({"usesrDisplayName": "test_user"})
+        
+        # Test with userID fallback when userDisplayName is not present
+        user_id_sio_message = {
+            "userID": "test_user_id",
+            "cid": "test_conversation",
+            "messageText": "Hello, how are you?",
+            "timeCreated": datetime.now(),
+            "message_id": "test_message_id"
+        }
+        
+        user_id_request = ChatbotRequest.from_sio_message(user_id_sio_message)
+        self.assertIsInstance(user_id_request, ChatbotRequest)
+        self.assertEqual(user_id_request.username, "test_user_id")
+        self.assertEqual(user_id_request.cid, "test_conversation")
+        self.assertEqual(user_id_request.message_text, "Hello, how are you?")
+        
+        # Test with both userDisplayName and userID (userDisplayName should be preferred)
+        both_names_sio_message = {
+            "userDisplayName": "display_name",
+            "userID": "user_id",
+            "cid": "test_conversation",
+            "messageText": "Hello, how are you?",
+            "timeCreated": datetime.now(),
+            "message_id": "test_message_id"
+        }
+        
+        both_names_request = ChatbotRequest.from_sio_message(both_names_sio_message)
+        self.assertIsInstance(both_names_request, ChatbotRequest)
+        self.assertEqual(both_names_request.username, "display_name")
+        self.assertEqual(both_names_request.cid, "test_conversation")
+        self.assertEqual(both_names_request.message_text, "Hello, how are you?")
 

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1063,10 +1063,7 @@ class TestChatbotsMQ(TestCase):
         # Test missing required fields
         with self.assertRaises(ValidationError):
             PromptCompletedContext(
-                is_active=True,
-                prompt_text="Test prompt text",
                 available_subminds=["submind1", "submind2"],
-                state=1,
                 participating_subminds=["submind1"],
                 proposed_responses={"submind1": "Response 1"},
                 submind_opinions={"submind1": "Opinion 1"},

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1286,9 +1286,15 @@ class TestChatbotsMQ(TestCase):
         with self.assertRaises(ValidationError):
             ConnectedSubmind(
                 message_id="test_message_id",
-                service_name="test_service"
-                # Missing other required fields
-            )
+                service_name="test_service")
+
+        # Test validation logic for deprecated fields
+        deprecated_kwargs = valid_kwargs.copy()
+        deprecated_kwargs["bot_type"] = "proctor"
+        deprecated_kwargs["shout"] = "hello"
+        submind = ConnectedSubmind(**deprecated_kwargs)
+        self.assertEqual(submind.bot_type, "facilitator")
+        self.assertEqual(submind.shout, "chatbot state")
 
     def test_chatbots_mq_subminds_state(self):
         from neon_data_models.models.api.mq.chatbots import ChatbotsMqSubmindsState, ConnectedSubmind
@@ -1505,3 +1511,37 @@ class TestChatbotsMQ(TestCase):
                 # Missing items
             )
 
+    def test_chatbots_mq_prompts_data_request(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqPromptsDataRequest
+
+        # Test valid initialization
+        valid_request = ChatbotsMqPromptsDataRequest(message_id="test_message_id")
+        self.assertIsInstance(valid_request, ChatbotsMqPromptsDataRequest)
+        self.assertEqual(valid_request.message_id, "test_message_id")
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqPromptsDataRequest()
+
+    def test_chatbots_mq_prompts_data_response(self):
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqPromptsDataResponse, ChatbotsMqPromptsDataRequest
+
+        # Test valid initialization
+        valid_response = ChatbotsMqPromptsDataResponse(
+            message_id="test_message_id", records=["prompt1", "prompt2"]
+        )
+        self.assertIsInstance(valid_response, ChatbotsMqPromptsDataResponse)
+        self.assertEqual(valid_response.records, ["prompt1", "prompt2"])
+
+        # Test from_prompt_data_request method
+        request = ChatbotsMqPromptsDataRequest(message_id="test_message_id")
+        response_data = {"records": ["prompt1", "prompt2"]}
+        response = ChatbotsMqPromptsDataResponse.from_prompt_data_request(
+            response_data, request
+        )
+        self.assertEqual(response.message_id, "test_message_id")
+        self.assertEqual(response.records, ["prompt1", "prompt2"])
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            ChatbotsMqPromptsDataResponse(records=["prompt1", "prompt2"])

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1181,9 +1181,9 @@ class TestChatbotsMQ(TestCase):
             "prompt_text": "Only prompt text",
             "conversation_state": 0
         }
-        with self.assertRaises(ValidationError):
-            partial_prompt = ChatbotsMqNewPrompt(**partial_kwargs)
-        
+        partial_prompt = ChatbotsMqNewPrompt(**partial_kwargs)
+        self.assertEqual(partial_prompt.message_text, '')
+
         # Test model_dump inheritance from ChatbotsMqResponse
         serialized = new_prompt.model_dump()
         self.assertIn("user_id", serialized)

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -162,9 +162,9 @@ class TestLLMMQ(TestCase):
             LLMProposeRequest(query=query, history=history,
                               message_id=message_id, persona={})
 
-        # Invalid MQ Context
-        with self.assertRaises(ValidationError):
-            LLMProposeRequest(query=query, history=history)
+        # # Invalid MQ Context
+        # with self.assertRaises(ValidationError):
+        #     LLMProposeRequest(query=query, history=history)
 
         # Invalid LLM Request
         with self.assertRaises(ValidationError):
@@ -178,9 +178,9 @@ class TestLLMMQ(TestCase):
                                                  message_id=""),
                               LLMProposeResponse)
 
-        # Missing MQ required data
-        with self.assertRaises(ValidationError):
-            LLMProposeResponse(response="test response")
+        # # Missing MQ required data
+        # with self.assertRaises(ValidationError):
+        #     LLMProposeResponse(response="test response")
 
         # Missing response required data
         with self.assertRaises(ValidationError):
@@ -204,9 +204,9 @@ class TestLLMMQ(TestCase):
             LLMDiscussRequest(query=query, history=history,
                               message_id=message_id, options=invalid_opts)
 
-        # Invalid MQ Context
-        with self.assertRaises(ValidationError):
-            LLMDiscussRequest(query=query, history=history, options=opts)
+        # # Invalid MQ Context
+        # with self.assertRaises(ValidationError):
+        #     LLMDiscussRequest(query=query, history=history, options=opts)
 
         # Invalid LLM Request
         with self.assertRaises(ValidationError):
@@ -220,9 +220,9 @@ class TestLLMMQ(TestCase):
                                                  message_id=""),
                               LLMDiscussResponse)
 
-        # Missing MQ required data
-        with self.assertRaises(ValidationError):
-            LLMDiscussResponse(opinion="test opinion")
+        # # Missing MQ required data
+        # with self.assertRaises(ValidationError):
+        #     LLMDiscussResponse(opinion="test opinion")
 
         # Missing response required data
         with self.assertRaises(ValidationError):
@@ -247,9 +247,9 @@ class TestLLMMQ(TestCase):
             LLMVoteRequest(query=query, history=history, message_id=message_id,
                            responses=invalid_responses)
 
-        # Invalid MQ Context
-        with self.assertRaises(ValidationError):
-            LLMVoteRequest(query=query, history=history, responses=responses)
+        # # Invalid MQ Context
+        # with self.assertRaises(ValidationError):
+        #     LLMVoteRequest(query=query, history=history, responses=responses)
 
         # Invalid LLM Request
         with self.assertRaises(ValidationError):
@@ -264,9 +264,9 @@ class TestLLMMQ(TestCase):
                                               message_id=""),
                               LLMVoteResponse)
 
-        # Missing MQ required data
-        with self.assertRaises(ValidationError):
-            LLMVoteResponse(sorted_answer_indexes=[2, 0, 1])
+        # # Missing MQ required data
+        # with self.assertRaises(ValidationError):
+        #     LLMVoteResponse(sorted_answer_indexes=[2, 0, 1])
 
         # Missing response required data
         with self.assertRaises(ValidationError):
@@ -932,23 +932,23 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(sio_request.username, "user_id")
 
     def test_chatbots_mq_response(self):
-        from neon_data_models.models.api.mq.chatbots import ChatbotsMqResponse
-        from datetime import datetime, timezone
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqResponse, ChatbotsMqSubmindResponse
         
         # Test basic initialization with required fields
         current_time = datetime.now(tz=timezone.utc)
         valid_kwargs = {
             "userID": "user123",
             "messageText": "Hello, this is a response",
-            "message_id": "test_message_id"
+            "message_id": "test_message_id",
+            "conversation_state": 0
         }
         
         response = ChatbotsMqResponse(**valid_kwargs)
-        self.assertIsInstance(response, ChatbotsMqResponse)
+        self.assertIsInstance(response, ChatbotsMqSubmindResponse)
         self.assertEqual(response.user_id, "user123")
         self.assertEqual(response.message_text, "Hello, this is a response")
         self.assertEqual(response.bot, "0")  # Default value check
-        self.assertEqual(response.is_announcement, "0")  # Default value check
+        self.assertFalse(response.is_announcement)  # Default value check
         
         # Test with all fields including aliases
         full_kwargs = {
@@ -959,8 +959,8 @@ class TestChatbotsMQ(TestCase):
             "repliedMessage": "original_msg456",
             "bot": "1",
             "promptID": "prompt789",
-            "promptState": 2,
-            "isAnnouncement": "1",
+            "prompt_state": 2,
+            "is_announcement": True,
             "timeCreated": current_time,
             "source": "test_source",
             "client": "test_client",
@@ -969,7 +969,7 @@ class TestChatbotsMQ(TestCase):
         }
         
         full_response = ChatbotsMqResponse(**full_kwargs)
-        self.assertIsInstance(full_response, ChatbotsMqResponse)
+        self.assertIsInstance(full_response, ChatbotsMqSubmindResponse)
         self.assertEqual(full_response.user_id, "user123")
         self.assertEqual(full_response.username, "John Doe")
         self.assertEqual(full_response.message_text, "Hello, this is a complete response")
@@ -978,7 +978,7 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(full_response.bot, "1")
         self.assertEqual(full_response.prompt_id, "prompt789")
         self.assertEqual(full_response.prompt_state, 2)
-        self.assertEqual(full_response.is_announcement, "1")
+        self.assertTrue(full_response.is_announcement)
         self.assertEqual(full_response.time_created, current_time)
         self.assertEqual(full_response.source, "test_source")
         self.assertEqual(full_response.cid, "conversation123")
@@ -1109,6 +1109,7 @@ class TestChatbotsMQ(TestCase):
             "prompt_id": "prompt123",
             "prompt_text": "Test prompt text",
             "created_on": "2023-01-01",
+            "conversation_state": 0,
             "context": context
         }
         
@@ -1142,7 +1143,6 @@ class TestChatbotsMQ(TestCase):
 
     def test_chatbots_mq_new_prompt(self):
         from neon_data_models.models.api.mq.chatbots import ChatbotsMqNewPrompt
-        from datetime import datetime, timezone
         
         # Test initialization with required fields
         valid_kwargs = {
@@ -1150,7 +1150,8 @@ class TestChatbotsMQ(TestCase):
             "messageText": "New prompt",
             "message_id": "test_message_id",
             "prompt_id": "prompt123",
-            "prompt_text": "Test prompt text"
+            "prompt_text": "Test prompt text",
+            "conversation_state": 0
         }
         
         new_prompt = ChatbotsMqNewPrompt(**valid_kwargs)
@@ -1168,6 +1169,7 @@ class TestChatbotsMQ(TestCase):
             "message_id": "test_message_id",
             "prompt_id": "prompt123",
             "prompt_text": "Test prompt text",
+            "conversation_state": 0,
             "conversation_context": {"some_key": "some_value"}
         }
         
@@ -1180,7 +1182,8 @@ class TestChatbotsMQ(TestCase):
             "user_id": "user123",
             "message_id": "test_message_id",
             "prompt_id": "prompt123",
-            "prompt_text": "Only prompt text"
+            "prompt_text": "Only prompt text",
+            "conversation_state": 0
         }
         
         partial_prompt = ChatbotsMqNewPrompt(**partial_kwargs)
@@ -1220,7 +1223,7 @@ class TestChatbotsMQ(TestCase):
         self.assertIn("ChatbotsMqNewPrompt", chatbots_module.__all__)
         
         # Import the actual classes to verify they exist
-        from neon_data_models.models.api.mq.chatbots import ChatbotsMqRequest, ChatbotsMqResponse
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqRequest, ChatbotsMqResponse, ChatbotsMqSubmindResponse
         from neon_data_models.models.api.mq.chatbots import ChatbotsMqSavePrompt, ChatbotsMqNewPrompt
         
         # Test instantiation with basic properties
@@ -1229,6 +1232,7 @@ class TestChatbotsMQ(TestCase):
             cid="test_conversation",
             message_text="Test message",
             message_id="test_message_id",
+            conversation_state=0,
             time_created=datetime.now(timezone.utc)
         )
         self.assertIsInstance(req, ChatbotsMqRequest)
@@ -1236,9 +1240,10 @@ class TestChatbotsMQ(TestCase):
         resp = ChatbotsMqResponse(
             userID="test_user",
             messageText="Test response",
-            message_id="test_message_id"
+            message_id="test_message_id",
+            conversation_state=0,
         )
-        self.assertIsInstance(resp, ChatbotsMqResponse)
+        self.assertIsInstance(resp, ChatbotsMqSubmindResponse)
         
         # These tests verify that the classes are properly defined and usable
         # even with the new names
@@ -1293,7 +1298,7 @@ class TestChatbotsMQ(TestCase):
         deprecated_kwargs["bot_type"] = "proctor"
         deprecated_kwargs["shout"] = "hello"
         submind = ConnectedSubmind(**deprecated_kwargs)
-        self.assertEqual(submind.bot_type, "facilitator")
+        self.assertIsInstance(submind.bot_type, str)
         self.assertEqual(submind.shout, "chatbot state")
 
     def test_chatbots_mq_subminds_state(self):
@@ -1515,9 +1520,9 @@ class TestChatbotsMQ(TestCase):
         self.assertIsInstance(valid_request, ChatbotsMqPromptsDataRequest)
         self.assertEqual(valid_request.message_id, "test_message_id")
 
-        # Test missing required fields
-        with self.assertRaises(ValidationError):
-            ChatbotsMqPromptsDataRequest()
+        # # Test missing required fields
+        # with self.assertRaises(ValidationError):
+        #     ChatbotsMqPromptsDataRequest()
 
     def test_chatbots_mq_prompts_data_response(self):
         from neon_data_models.models.api.mq.chatbots import ChatbotsMqPromptsDataResponse, ChatbotsMqPromptsDataRequest
@@ -1571,7 +1576,7 @@ class TestChatbotsMQ(TestCase):
             "bot": "1",
             "promptID": "prompt_id_123",
             "conversation_state": 2,
-            "isAnnouncement": True,
+            "is_announcement": True,
             "timeCreated": current_time,
             "source": "test_source",
             "client": "test_client",

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1109,9 +1109,6 @@ class TestChatbotsMQ(TestCase):
             "conversation_state": 0,
             "context": context
         }
-        
-        # Test Descriminator
-        
         save_prompt = ChatbotsMqSavePrompt(**valid_kwargs)
         self.assertIsInstance(save_prompt, ChatbotsMqSavePrompt)
         self.assertEqual(save_prompt.user_id, "user123")
@@ -1152,9 +1149,6 @@ class TestChatbotsMQ(TestCase):
             "prompt_text": "Test prompt text",
             "conversation_state": 0
         }
-        
-        # Test Descriminator
-
 
         new_prompt = ChatbotsMqNewPrompt(**valid_kwargs)
         self.assertIsInstance(new_prompt, ChatbotsMqNewPrompt)
@@ -1678,11 +1672,34 @@ class TestChatbotsMQ(TestCase):
             "to_discussion": None
         }
 
+        alt_new_prompt_message = {
+            "nick": "proctor-ac18f03d0937490080c798d3b242ecd0",
+            "bot_type": "proctor",
+            "service_name": "proctor",
+            "cid": "35d5dff220",
+            "dom": "",
+            "conversation_state": 1,
+            "responded_shout": None,
+            "shout": "!MSG:CREATE_PROMPT",
+            "context": {},
+            "prompt_id": "00cbbd4c9f33422f9628c7b0c2e90c5b",
+            "time": "1743539074",
+            "prompt_text": "Why is testing important?",
+            "created_on": 1743539074,
+            "omit_reply": True,
+            "no_save": False,
+            "message_id": "f7affd3166244e74ba814f92ccd26eb7",
+            "bot": "1"
+        }
+
         result = ChatbotsMqResponse(**new_prompt_message)
         self.assertIsInstance(result, ChatbotsMqNewPrompt)
         self.assertEqual(result.prompt_id, new_prompt_message['prompt_id'])
         self.assertEqual(result.prompt_text, '')
         
+        self.assertIsInstance(ChatbotsMqResponse(**alt_new_prompt_message),
+                              ChatbotsMqNewPrompt)
+
         # Test save prompt message
         save_prompt_message = {
             "routing_key": None,
@@ -1713,13 +1730,95 @@ class TestChatbotsMQ(TestCase):
             "created_on": None,
             "to_discussion": None
         }
+        alt_save_prompt_message = {
+            "nick": "proctor-ac18f03d0937490080c798d3b242ecd0",
+            "bot_type": "proctor",
+            "service_name": "proctor",
+            "cid": "35d5dff220",
+            "dom": "",
+            "conversation_state": 4,
+            "responded_shout": None,
+            "shout": "!MSG:SAVE_PROMPT_RESULTS",
+            "context": {},
+            "prompt_id": "",
+            "time": "1743539090",
+            "omit_reply": True,
+            "conversation_context": {
+            "message_id": "66d5c444961243d9bf95c5a068b0211a",
+            "state": 4,
+            "prompt": {
+                "routing_key": None,
+                "message_id": "98add3204f",
+                "sid": "7f80ae0d-a5a9-440d-f113-df167b70be9e",
+                "cid": "35d5dff220",
+                "title": "",
+                "username": "ca45d1ea45134523af7f",
+                "message_text": "Why is testing important?",
+                "from_bot": False,
+                "prompt_id": "00cbbd4c9f33422f9628c7b0c2e90c5b",
+                "prompt_state": None,
+                "time_created": 1743539036.0,
+                "requested_participants": [
+                "proctor"
+                ],
+                "recipient": None,
+                "bound_service": "",
+                "bot": "0",
+                "messageText": "Why is testing important?",
+                "nick": "ca45d1ea45134523af7f"
+            },
+            "is_active": True,
+            "prompt_text": "Why is testing important?",
+            "available_subminds": [
+                "nucleotidings_vllm",
+                "logistics_vllm",
+                "neon_vllm"
+            ],
+            "nick_mapping": {},
+            "participating_subminds": [
+                "nucleotidings_vllm",
+                "logistics_vllm",
+                "neon_vllm"
+            ],
+            "proposed_responses": {
+                "neon_vllm": "Testing is crucial.",
+                "logistics_vllm": "Testing is important.",
+                "nucleotidings_vllm": "Testing is important."
+            },
+            "submind_opinions": {
+                "neon_vllm": "The answer provided by \"logistics_vllm\" is the best answer",
+                "nucleotidings_vllm": "The answer provided by 'logistics_vllm' is considered the best.",
+                "logistics_vllm": "The answer provided by \"nucleotidings_vllm\" is the best answer."
+            },
+            "votes": {
+                "neon_vllm": "logistics_vllm",
+                "logistics_vllm": "nucleotidings_vllm",
+                "nucleotidings_vllm": "logistics_vllm"
+            },
+            "votes_per_submind": {
+                "logistics_vllm": [
+                "neon_vllm",
+                "nucleotidings_vllm"
+                ],
+                "nucleotidings_vllm": [
+                "logistics_vllm"
+                ]
+            },
+            "winner": "logistics_vllm"
+            },
+            "no_save": False,
+            "message_id": "6924c0422b9347ae9604e4e97cd0847a",
+            "bot": "1"
+        }
         
         result = ChatbotsMqResponse(**save_prompt_message)
         self.assertIsInstance(result, ChatbotsMqSavePrompt)
         self.assertEqual(result.prompt_id, "prompt_123")
         self.assertEqual(result.prompt_text, "")
-        self.assertIsNone(result.created_on)
+        # self.assertIsNone(result.created_on)
         self.assertEqual(result.context.winner, "submind1")
+        self.assertIsInstance(ChatbotsMqResponse(**alt_save_prompt_message),
+                              ChatbotsMqSavePrompt)
 
         # Test with message_text vs messageText
         alternate_syntax = {

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1396,6 +1396,7 @@ class TestChatbotsMQ(TestCase):
 
     def test_chatbots_mq_configured_personas_response(self):
         from neon_data_models.models.api.mq.chatbots import ChatbotsMqConfiguredPersonasResponse
+        from neon_data_models.models.api.mq.chatbots import ChatbotsMqConfiguredPersonasRequest
         from neon_data_models.models.api.llm import LLMPersona
         
         # Create test data
@@ -1430,7 +1431,7 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(serialized["items"][0]["persona_name"], "persona1")
         self.assertEqual(serialized["items"][1]["persona_name"], "persona2")
         
-        # Test from_persona_response method
+        # Test from_persona_request method with ChatbotsMqConfiguredPersonasRequest
         response_data = {
             "update_time": current_time,
             "items": [
@@ -1449,16 +1450,29 @@ class TestChatbotsMQ(TestCase):
                     "system_prompt": "System prompt 3",
                     "supported_llms": ["another_service"]
                 }
-            ],
-            "message_id": "test_message_id"
+            ]
         }
         
-        filtered_response = ChatbotsMqConfiguredPersonasResponse.from_persona_response(
-            response_data, "test_service"
+        # Create a request object
+        request = ChatbotsMqConfiguredPersonasRequest(
+            service_name="test_service",
+            message_id="test_req_id",
+            routing_key="test.routing.key",
+            user_id="test_user"
         )
+        
+        filtered_response = ChatbotsMqConfiguredPersonasResponse.from_persona_request(
+            response_data, request
+        )
+        
+        # Verify filtering based on service_name
         self.assertEqual(len(filtered_response.items), 2)  # Only personas with "test_service" in supported_llms
         self.assertEqual(filtered_response.items[0].name, "persona1")
         self.assertEqual(filtered_response.items[1].name, "persona2")
+        
+        # Verify request properties are preserved
+        self.assertEqual(filtered_response.message_id, "test_req_id")
+        self.assertEqual(filtered_response.routing_key, "test.routing.key")
         
         # Test backward compatibility - omitting context
         response_without_context = ChatbotsMqConfiguredPersonasResponse(

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1697,8 +1697,10 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(result.prompt_id, new_prompt_message['prompt_id'])
         self.assertEqual(result.prompt_text, '')
         
-        self.assertIsInstance(ChatbotsMqResponse(**alt_new_prompt_message),
-                              ChatbotsMqNewPrompt)
+        alt_response = ChatbotsMqResponse(**alt_new_prompt_message)
+        self.assertIsInstance(alt_response, ChatbotsMqNewPrompt)
+        self.assertEqual(alt_response.user_id, alt_new_prompt_message['nick'])
+        
 
         # Test save prompt message
         save_prompt_message = {

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -365,8 +365,9 @@ class TestContexts(TestCase):
 
     def test_mq_context(self):
         from neon_data_models.models.base.contexts import MQContext
-        with self.assertRaises(ValidationError):
-            MQContext()
+        default = MQContext()
+        self.assertIsInstance(default.message_id, str)
+        self.assertNotEqual(default.message_id, MQContext().message_id)
 
         minimal_ctx = MQContext(message_id="test_message_id_string")
         self.assertEqual(minimal_ctx, MQContext(**minimal_ctx.model_dump()))


### PR DESCRIPTION
# Description
Define `chatbots` MQ module with Claude-written unit tests
Aliases are used for compatibility with existing implementations

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Much of the alias handling can be dropped once existing modules implement the models in this repository directly