### PR TITLE
Update `chatbots` MQ models to improve validation and backwards-compat

### DIFF
--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -58,7 +58,7 @@ class ChatbotsMqRequest(KlatContext, MQContext):
         default= datetime.now(tz=timezone.utc),
         description="Timestamp when the shout was created")
     requested_participants: Optional[List[str]] = Field(
-        default=None, 
+        default=None, alias="participating_subminds",
         description="List of CCAI participants requested to handle the shout")
     recipient: Optional[str] = Field(
         default=None, description="Explicitly defined recipient of the shout")
@@ -150,6 +150,12 @@ class ChatbotsMqSubmindResponse(KlatContext, MQContext):
         default=CcaiState.IDLE, deprecated=True, alias="promptState",
         description="State of the CCAI conversation associated with the shout")
     
+    @model_validator(mode='after')
+    def set_username_from_user_id(self):
+        if self.username is None and self.user_id:
+            self.username = self.user_id.rsplit('-', 1)[0]
+        return self
+
     @model_validator(mode='before')
     @classmethod
     def validate_inputs(cls, values):

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1610,6 +1610,48 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(serialized["nick"], "submind1")  # Check backwards compatibility field
         self.assertEqual(serialized["shout"], "Full test response")  # Check backwards compatibility field
         
+
+        # Test username from user_id with a single hyphen
+        hyphen_user_id = ChatbotsMqSubmindResponse(
+            userID="service-123456",
+            messageText="Test message",
+            message_id="test_id"
+        )
+        self.assertEqual(hyphen_user_id.username, "service")
+
+        # Test username from user_id with multiple hyphens
+        multiple_hyphens = ChatbotsMqSubmindResponse(
+            userID="service-name-with-hyphens-123456",
+            messageText="Test message",
+            message_id="test_id"
+        )
+        self.assertEqual(multiple_hyphens.username, "service-name-with-hyphens")
+
+        # Test username from user_id without hyphen
+        no_hyphen = ChatbotsMqSubmindResponse(
+            userID="servicename",
+            messageText="Test message", 
+            message_id="test_id"
+        )
+        self.assertEqual(no_hyphen.username, "servicename")
+
+        # Test existing username is preserved when both fields are provided
+        preserved_username = ChatbotsMqSubmindResponse(
+            userID="service-123456",
+            username="custom_name",
+            messageText="Test message",
+            message_id="test_id"
+        )
+        self.assertEqual(preserved_username.username, "custom_name")
+
+        # Test when user_id is None
+        with self.assertRaises(ValidationError):
+            none_user_id = ChatbotsMqSubmindResponse(
+                userID=None,
+                messageText="Test message",
+                message_id="test_id"
+            )
+
         # Test missing required fields
         with self.assertRaises(ValidationError):
             ChatbotsMqSubmindResponse(messageText="Missing user_id", message_id="test_id")

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -1645,12 +1645,13 @@ class TestChatbotsMQ(TestCase):
         self.assertEqual(preserved_username.username, "custom_name")
 
         # Test when user_id is None
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as e:
             none_user_id = ChatbotsMqSubmindResponse(
                 userID=None,
                 messageText="Test message",
                 message_id="test_id"
             )
+            self.assertEqual(str(e), "user_id cannot be None")
 
         # Test missing required fields
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
# Description
Populates `username` from `user_id` if not specified
Add `participating_subminds` alias for `requested_participants` for Proctor compat.

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->