### PR TITLE
Fix type annotation for `user_profiles` context to match expected format

### DIFF
--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -31,7 +31,7 @@ from neon_data_models.models.base import BaseModel
 from neon_data_models.models.base.contexts import KlatContext, MQContext, \
     SessionContext, TimingContext
 from neon_data_models.models.base.messagebus import BaseMessage, MessageContext
-from neon_data_models.models.user.database import NeonUserConfig
+from neon_data_models.models.user.neon_profile import UserProfile
 from neon_data_models.models.api.messagebus import NeonGetLanguages, NeonGetTts, NeonGetStt, \
     NeonAudioInput, NeonLanguagesResponse, NeonTextInput, NeonSttResponse, NeonTtsResponse
 
@@ -170,7 +170,7 @@ class NeonApiMessage:
                                  client=sio_message.get("client", "unknown"),
                                  username=sio_message.get("nick", "guest"),
                                  klat_data=klat_context, mq=mq_context,
-                                 user_profiles=[NeonUserConfig()],
+                                 user_profiles=[UserProfile()],
                                  session=SessionContext(
                                      session_id=sio_message.get("cid", "klat")),
                                  timing=TimingContext(

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -32,7 +32,7 @@ from neon_data_models.models.base.contexts import (GradioContext,
                                                    SessionContext, KlatContext,
                                                    TimingContext, MQContext)
 from neon_data_models.models.client.node import NodeData
-from neon_data_models.models.user.database import NeonUserConfig
+from neon_data_models.models.user.neon_profile import UserProfile
 
 
 class MessageContext(BaseModel):
@@ -43,7 +43,7 @@ class MessageContext(BaseModel):
     timing: TimingContext = Field(
         description="User Interaction Timing Information", 
         default=TimingContext())
-    user_profiles: Optional[List[NeonUserConfig]] = (
+    user_profiles: Optional[List[UserProfile]] = (
         Field(description="List of relevant user profiles", default=None))
     klat_data: Optional[KlatContext] = Field(
         description="Klat context for Klat-generated messages", default=None)

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -378,7 +378,7 @@ class TestMessagebus(TestCase):
         from ovos_bus_client.message import Message
         from neon_data_models.models.base.messagebus import BaseMessage
         from neon_data_models.models.client import NodeData
-        from neon_data_models.models.user import NeonUserConfig
+        from neon_data_models.models.user import UserProfile
 
         with self.assertRaises(ValidationError):
             BaseMessage()
@@ -395,7 +395,7 @@ class TestMessagebus(TestCase):
                                                 "extra_key": "text"})
         # Defined keys will generate objects
         self.assertIsInstance(message.context.node_data, NodeData)
-        self.assertIsInstance(message.context.user_profiles[0], NeonUserConfig)
+        self.assertIsInstance(message.context.user_profiles[0], UserProfile)
 
         as_messagebus = message.as_messagebus_message()
         self.assertIsInstance(as_messagebus, Message)
@@ -413,7 +413,7 @@ class TestMessagebus(TestCase):
     def test_message_context(self):
         from neon_data_models.models.base.messagebus import MessageContext
         from neon_data_models.models.client import NodeData
-        from neon_data_models.models.user import NeonUserConfig
+        from neon_data_models.models.user import UserProfile
 
         # Default Behavior
         default_context = MessageContext()
@@ -431,7 +431,7 @@ class TestMessagebus(TestCase):
         from neon_data_models.models.base.contexts import SessionContext
         self.assertIsInstance(extra_context.session, SessionContext)
         self.assertIsInstance(extra_context.node_data, NodeData)
-        self.assertIsInstance(extra_context.user_profiles[0], NeonUserConfig)
+        self.assertIsInstance(extra_context.user_profiles[0], UserProfile)
         from neon_data_models.models.base.contexts import KlatContext
         self.assertIsInstance(extra_context.klat_data, KlatContext)
         from neon_data_models.models.base.contexts import MQContext


### PR DESCRIPTION
# Description
Changes `message.context.user_profiles` to use the data format expected in `neon-core` services

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->