### PR TITLE
Specify `discussion_rounds` in new prompt model

### DIFF
--- a/neon_data_models/models/api/mq/chatbots.py
+++ b/neon_data_models/models/api/mq/chatbots.py
@@ -249,6 +249,9 @@ class ChatbotsMqNewPrompt(ChatbotsMqSubmindResponse):
     prompt_state: CcaiState = Field(
         default=CcaiState.IDLE, deprecated=True,
         description="Implemented for backwards-compat. New Prompt always IDLE")
+    discussion_rounds: int = Field(
+        default=2, 
+        description="Number of discussion rounds per cycle for this prompt")
     context: Optional[dict] = Field(default=None, deprecated=True,
                                     alias="conversation_context")
 


### PR DESCRIPTION
# Description
Adds a parameter to include the number of discussion rounds to be completed for a new prompt

# Issues
Related to https://github.com/NeonGeckoCom/chat-facilitator-proctor/pull/20

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->