### PR TITLE
Implement OpenAI Completion request/response models with unit tests

### DIFF
--- a/neon_data_models/models/api/http/brainforge.py
+++ b/neon_data_models/models/api/http/brainforge.py
@@ -24,11 +24,18 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import List, Optional
+from typing import List, Optional, Dict, Literal
+from uuid import uuid4
+from time import time
 from pydantic import Field, model_validator
 
 from neon_data_models.models.base import BaseModel
-from neon_data_models.models.api.llm import BrainForgeLLM, LLMPersona, LLMRequest
+from neon_data_models.models.api.llm import (
+    BrainForgeLLM,
+    LLMPersona,
+    LLMRequest,
+    LLMResponse,
+)
 
 
 class LLMGetModelsHttpResponse(BaseModel):
@@ -37,28 +44,132 @@ class LLMGetModelsHttpResponse(BaseModel):
 
 class LLMGetPersonasHttpRequest(BaseModel):
     model_id: str = Field(
-        description="Model ID (<name>@<version>) to get personas for")
+        description="Model ID (<name>@<version>) to get personas for"
+    )
 
 
 class LLMGetPersonasHttpResponse(BaseModel):
     personas: List[LLMPersona] = Field(
-        description="List of personas associated with the requested model.")
+        description="List of personas associated with the requested model."
+    )
 
 
 class LLMGetInferenceHttpRequest(LLMRequest):
     llm_name: str = Field(description="Model name to request")
     llm_revision: str = Field(description="Model revision to request")
     model: Optional[str] = Field(
-        default=None, 
-        description="Model ID (<name>@<version>) used for vLLM inference")
+        default=None,
+        description="Model ID (<name>@<version>) used for vLLM inference",
+    )
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def set_model_from_name_and_revision(self):
         if self.model is None:
             self.model = f"{self.llm_name}@{self.llm_revision}"
         return self
 
-__all__ = [LLMGetModelsHttpResponse.__name__,
-           LLMGetPersonasHttpRequest.__name__,
-           LLMGetPersonasHttpResponse.__name__,
-           LLMGetInferenceHttpRequest.__name__]
+
+class OpenAiCompletionRequest(BaseModel):
+    model: str = Field(description="Model ID (generally <name>@<version>)")
+    messages: List[Dict[Literal["role", "content"], str]] = Field(
+        description="List of messages to send to the model for completion, "
+        "including `system` and other context messages."
+    )
+    max_tokens: Optional[int] = Field(
+        default=512, description="Maximum number of tokens to generate"
+    )
+    temperature: Optional[float] = Field(
+        default=0.0, description="Temperature of generation"
+    )
+    stream: Optional[bool] = Field(
+        default=False, description="Not Implemented."
+    )
+    persona: Optional[LLMPersona] = Field(default=None)
+
+    @model_validator(mode="after")
+    def ensure_default_values(self):
+        """Set default values for compat with BrainForge API."""
+        self.max_tokens = self.max_tokens or 512
+        self.temperature = self.temperature or 0.0
+        if self.stream is None:
+            self.stream = False
+        return self
+
+    @model_validator(mode="after")
+    def get_persona(self):
+        """Determine a persona based on message history or default vanilla."""
+        for message in self.messages:
+            if message["role"] == "system":
+                sys_message = self.messages.pop(self.messages.index(message))
+                if sys_message["content"]:
+                    self.persona = LLMPersona(
+                        name="custom", system_prompt=sys_message["content"]
+                    )
+                    return self
+                break
+        self.persona = LLMPersona(name="vanilla", system_prompt=None)
+        return self
+
+    @model_validator(mode="after")
+    def validate_messages(self):
+        if len(self.messages) < 1:
+            raise ValueError("At least one `user` message is required.")
+
+    def to_llm_inference_http_request(self) -> LLMGetInferenceHttpRequest:
+        """
+        Convert this OpenAI completion request to LLMGetInferenceHttpRequest
+        """
+        model, revision = self.model.split("@", 1)
+        query = self.messages.pop(-1)["content"]
+        history = [(msg["role"], msg["content"]) for msg in self.messages]
+        return LLMGetInferenceHttpRequest(
+            llm_name=model,
+            llm_revision=revision,
+            model=self.model,
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
+            query=query,
+            history=history,
+            persona=self.persona
+        )
+
+
+class OpenAiCompletionResponse(BaseModel):
+    id: str = Field(
+        description="UID for this completion request",
+        default_factory=lambda: uuid4().hex,
+    )
+    object: Literal["chat.completion"] = "chat.completion"
+    created: float = Field(
+        description="Timestamp of completion request",
+        default_factory=lambda: time(),
+    )
+    model: str = Field(description="Model ID used for this completion")
+    choices: List[
+        Dict[Literal["message"], Dict[Literal["role", "content"], str]]
+    ] = Field(description="List of responses from the model")
+
+    @classmethod
+    def from_llm_response(
+        cls, llm_response: LLMResponse, llm_request: OpenAiCompletionRequest
+    ) -> "OpenAiCompletionResponse":
+        """Get an OpenAI response from a BrainForge LLMResponse."""
+        choices = [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": llm_response.response,
+                }
+            }
+        ]
+        return cls(model=llm_request.model, choices=choices)
+
+
+__all__ = [
+    LLMGetModelsHttpResponse.__name__,
+    LLMGetPersonasHttpRequest.__name__,
+    LLMGetPersonasHttpResponse.__name__,
+    LLMGetInferenceHttpRequest.__name__,
+    OpenAiCompletionRequest.__name__,
+    OpenAiCompletionResponse.__name__,
+]

--- a/neon_data_models/models/api/http/brainforge.py
+++ b/neon_data_models/models/api/http/brainforge.py
@@ -86,6 +86,26 @@ class OpenAiCompletionRequest(BaseModel):
     )
     persona: Optional[LLMPersona] = Field(default=None)
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "model": "<name>@<version>",
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": "You are a helpful assistant.",
+                        },
+                        {"role": "user", "content": "Who are you?"},
+                    ],
+                    "max_tokens": 512,
+                    "temperature": 0.0,
+                    "stream": False,
+                }
+            ]
+        }
+    }
+
     @model_validator(mode="after")
     def ensure_default_values(self):
         """Set default values for compat with BrainForge API."""
@@ -130,7 +150,7 @@ class OpenAiCompletionRequest(BaseModel):
             temperature=self.temperature,
             query=query,
             history=history,
-            persona=self.persona
+            persona=self.persona,
         )
 
 
@@ -148,6 +168,27 @@ class OpenAiCompletionResponse(BaseModel):
     choices: List[
         Dict[Literal["message"], Dict[Literal["role", "content"], str]]
     ] = Field(description="List of responses from the model")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "id": uuid4().hex,
+                    "object": "chat.completion",
+                    "created": time(),
+                    "model": "<name>@<version>",
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "This is a sample response",
+                            }
+                        }
+                    ],
+                }
+            ]
+        }
+    }
 
     @classmethod
     def from_llm_response(

--- a/neon_data_models/models/api/http/brainforge.py
+++ b/neon_data_models/models/api/http/brainforge.py
@@ -24,7 +24,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import List, Optional, Dict, Literal
+from typing import List, Optional, Dict, Literal, Any
 from uuid import uuid4
 from time import time
 from pydantic import Field, model_validator
@@ -85,6 +85,7 @@ class OpenAiCompletionRequest(BaseModel):
         default=False, description="Not Implemented."
     )
     persona: Optional[LLMPersona] = Field(default=None)
+    extra_body: Optional[Dict[str, Any]] = Field(default=None)
 
     model_config = {
         "json_schema_extra": {
@@ -101,6 +102,10 @@ class OpenAiCompletionRequest(BaseModel):
                     "max_tokens": 512,
                     "temperature": 0.0,
                     "stream": False,
+                    "extra_body": {
+                        "use_beam_search": True,
+                        "best_of": 3,
+                    }
                 }
             ]
         }
@@ -113,6 +118,8 @@ class OpenAiCompletionRequest(BaseModel):
         self.temperature = self.temperature or 0.0
         if self.stream is None:
             self.stream = False
+        if self.extra_body is None:
+            self.extra_body = {}
         return self
 
     @model_validator(mode="after")
@@ -134,6 +141,7 @@ class OpenAiCompletionRequest(BaseModel):
     def validate_messages(self):
         if len(self.messages) < 1:
             raise ValueError("At least one `user` message is required.")
+        return self
 
     def to_llm_inference_http_request(self) -> LLMGetInferenceHttpRequest:
         """
@@ -151,6 +159,7 @@ class OpenAiCompletionRequest(BaseModel):
             query=query,
             history=history,
             persona=self.persona,
+            **self.extra_body
         )
 
 

--- a/neon_data_models/models/api/llm.py
+++ b/neon_data_models/models/api/llm.py
@@ -121,6 +121,9 @@ class LLMRequest(BaseModel):
         for idx, itm in enumerate(values.get('history', [])):
             if itm[0] == "assistant":
                 values['history'][idx] = ("llm", itm[1])
+        # OpenAI `extra_body` may be included in input; parse those inputs
+        if values.get('use_beam_search') is not None:
+            values['beam_search'] = values['use_beam_search']
         return values
 
     @model_validator(mode='after')
@@ -161,7 +164,7 @@ class LLMRequest(BaseModel):
 
         # If beam search is enabled, temperature must be set to 0.0
         if self.beam_search:
-            assert self.temperature == 0.0
+            assert self.temperature == 0.0, "Beam search requires temperature 0"
         return self
 
     @property

--- a/tests/models/api/test_http.py
+++ b/tests/models/api/test_http.py
@@ -1,0 +1,192 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2025 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from unittest import TestCase
+from pydantic import ValidationError
+
+from neon_data_models.models.api.llm import LLMPersona
+
+
+class TestBrainForgeHttp(TestCase):
+    def test_llm_get_inference_http_request(self):
+        from neon_data_models.models.api.http.brainforge import (
+            LLMGetInferenceHttpRequest,
+        )
+
+        # Valid request
+        valid_request = LLMGetInferenceHttpRequest(
+            llm_name="test_model",
+            llm_revision="1.0",
+            query="What is the weather like today?",
+            persona=LLMPersona(name="vanilla"),
+            history=[],
+            max_tokens=64,
+            temperature=0.7,
+            top_p=0.9,
+            stop_sequences=["\n"],
+            personas=["default"],
+        )
+        self.assertEqual(valid_request.llm_name, "test_model")
+        self.assertEqual(valid_request.llm_revision, "1.0")
+        self.assertEqual(valid_request.model, "test_model@1.0")
+        self.assertEqual(
+            valid_request.query, "What is the weather like today?"
+        )
+
+        # Invalid request (missing required llm_name)
+        with self.assertRaises(ValidationError):
+            LLMGetInferenceHttpRequest(
+                llm_revision="1.0", query="What is the weather like today?"
+            )
+
+    def test_openai_completion_request(self):
+        from neon_data_models.models.api.http.brainforge import (
+            OpenAiCompletionRequest,
+        )
+
+        # Valid no persona
+        valid_request_vanilla_persona = OpenAiCompletionRequest(
+            model="test_model@v1.0",
+            messages=[
+                {"role": "system", "content": ""},
+                {"role": "user", "content": "Hello, how are you?"},
+            ],
+            max_tokens=None,
+            temperature=None,
+            stream=None,
+        )
+        self.assertEqual(
+            valid_request_vanilla_persona.model, "test_model@v1.0"
+        )
+        self.assertIsInstance(valid_request_vanilla_persona.max_tokens, int)
+        self.assertIsInstance(valid_request_vanilla_persona.temperature, float)
+        self.assertIsInstance(valid_request_vanilla_persona.stream, bool)
+        self.assertIsInstance(
+            valid_request_vanilla_persona.persona, LLMPersona
+        )
+        self.assertEqual(valid_request_vanilla_persona.persona.name, "vanilla")
+        self.assertEqual(len(valid_request_vanilla_persona.messages), 1)
+
+        as_llm_request = (
+            valid_request_vanilla_persona.to_llm_inference_http_request()
+        )
+        self.assertEqual(as_llm_request.history, [])
+        self.assertEqual(as_llm_request.query, "Hello, how are you?")
+        self.assertEqual(
+            as_llm_request.model, valid_request_vanilla_persona.model
+        )
+
+        # Valid with system prompt
+        valid_request_custom_persona = OpenAiCompletionRequest(
+            model="test_model@v1.0",
+            messages=[
+                {"role": "system", "content": "Custom system prompt"},
+                {"role": "user", "content": "Hello, how are you?"},
+                {"role": "assistant", "content": "I'm fine, thank you!"},
+                {"role": "user", "content": "who are you?"},
+            ],
+            max_tokens=2048,
+            temperature=1.0,
+            stream=False,
+        )
+        self.assertIsInstance(valid_request_custom_persona.persona, LLMPersona)
+        self.assertEqual(valid_request_custom_persona.persona.name, "custom")
+        self.assertEqual(
+            valid_request_custom_persona.persona.system_prompt,
+            "Custom system prompt",
+        )
+        self.assertEqual(len(valid_request_custom_persona.messages), 3)
+
+        as_llm_request = (
+            valid_request_custom_persona.to_llm_inference_http_request()
+        )
+        self.assertEqual(len(as_llm_request.history), 2)
+        self.assertEqual(as_llm_request.query, "who are you?")
+        self.assertEqual(
+            as_llm_request.model, valid_request_custom_persona.model
+        )
+
+        # Valid without system prompt
+        valid_request_no_system = OpenAiCompletionRequest(
+            model="test_model@v1.0",
+            messages=[
+                {"role": "user", "content": "Hello, how are you?"},
+                {"role": "assistant", "content": "I'm fine, thank you!"},
+                {"role": "user", "content": "who are you?"},
+            ],
+            max_tokens=1024,
+            temperature=0.5,
+            stream=False,
+        )
+        self.assertIsInstance(valid_request_no_system.persona, LLMPersona)
+        self.assertEqual(valid_request_no_system.persona.name, "vanilla")
+        self.assertEqual(len(valid_request_no_system.messages), 3)
+
+        as_llm_request = (
+            valid_request_no_system.to_llm_inference_http_request()
+        )
+        self.assertEqual(len(as_llm_request.history), 2)
+        self.assertEqual(as_llm_request.query, "who are you?")
+        self.assertEqual(as_llm_request.model, valid_request_no_system.model)
+
+        # Invalid no history
+        with self.assertRaises(ValidationError):
+            OpenAiCompletionRequest(
+                model="test_model@v1.0",
+                messages=[],
+                max_tokens=1024,
+                temperature=0.5,
+                stream=False,
+            )
+
+    def test_openai_completion_response(self):
+        from neon_data_models.models.api.http.brainforge import (
+            OpenAiCompletionRequest,
+            OpenAiCompletionResponse,
+        )
+        from neon_data_models.models.api.llm import LLMResponse
+
+        # Valid response
+        llm_response = LLMResponse(
+            response="Hello", history=[("user", "hi"), ("llm", "Hello")]
+        )
+        oai_request = OpenAiCompletionRequest(
+            model="model_name@revision",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        response = OpenAiCompletionResponse.from_llm_response(
+            llm_response=llm_response, llm_request=oai_request
+        )
+        self.assertIsInstance(response.id, str)
+        self.assertEqual(response.object, "chat.completion")
+        self.assertIsInstance(response.created, float)
+        self.assertEqual(response.model, oai_request.model)
+        self.assertEqual(response.choices[0]["message"]["role"], "assistant")
+        self.assertEqual(
+            response.choices[0]["message"]["content"], llm_response.response
+        )
+

--- a/tests/models/api/test_http.py
+++ b/tests/models/api/test_http.py
@@ -138,8 +138,10 @@ class TestBrainForgeHttp(TestCase):
                 {"role": "user", "content": "who are you?"},
             ],
             max_tokens=1024,
-            temperature=0.5,
+            temperature=0.0,
             stream=False,
+            extra_body={"use_beam_search": True,
+                        "best_of": 3},
         )
         self.assertIsInstance(valid_request_no_system.persona, LLMPersona)
         self.assertEqual(valid_request_no_system.persona.name, "vanilla")
@@ -151,6 +153,7 @@ class TestBrainForgeHttp(TestCase):
         self.assertEqual(len(as_llm_request.history), 2)
         self.assertEqual(as_llm_request.query, "who are you?")
         self.assertEqual(as_llm_request.model, valid_request_no_system.model)
+        self.assertTrue(as_llm_request.beam_search)
 
         # Invalid no history
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
# Description
Implement Pydantic models for OpenAI Completion requests/responses that map to BrainForge request structures

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Implementing to support OpenAI-compatible endpoints in HANA (https://github.com/NeonGeckoCom/neon-hana/pull/42)