### PR TITLE
Implement models for the Skill API

### DIFF
--- a/neon_data_models/models/api/http/neon.py
+++ b/neon_data_models/models/api/http/neon.py
@@ -1,0 +1,55 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2024 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Dict
+from pydantic import BaseModel, Field
+from neon_data_models.models.api.messagebus import (
+    NeonSkillApiData,
+    SkillApiRequestData,
+    SkillApiResponseData,
+)
+
+
+class NeonHttpListResponse(BaseModel):
+    __root__: Dict[str, Dict[str, NeonSkillApiData]]
+
+
+class NeonHttpSkillApiRequest(SkillApiRequestData):
+    skill_id: str = Field(description="skill_id being requested")
+    skill_method: str = Field(description="API method being requested")
+
+
+class NeonHttpSkillApiResponse(SkillApiResponseData):
+    """
+    Convenience wrapper to implement examples for Swagger UI
+    """
+
+
+__all__ = [
+    NeonHttpListResponse.__name__,
+    NeonHttpSkillApiRequest.__name__,
+    NeonHttpSkillApiResponse.__name__,
+]

--- a/neon_data_models/models/api/http/neon.py
+++ b/neon_data_models/models/api/http/neon.py
@@ -35,9 +35,10 @@ from neon_data_models.models.api.messagebus import (
 
 class NeonSkillApiHttpData(NeonSkillApiData):
     skill_id: str = Field(
-            description="ID of the skill providing this API method")
-    api_method: str = Field(
-            description="API method name")
+        description="ID of the skill providing this API method"
+    )
+    api_method: str = Field(description="API method name")
+
 
 class NeonHttpListSkillApiResponse(RootModel):
     root: List[NeonSkillApiHttpData]
@@ -45,6 +46,47 @@ class NeonHttpListSkillApiResponse(RootModel):
     model_config = {
         "json_schema_extra": {
             "examples": [
+                {
+                    "help": "\n        API Method to build a list of examples as listed in skill metadata.\n        ",
+                    "request_schema": None,
+                    "response_schema": None,
+                    "signature": None,
+                    "type": "skill-about.neongeckocom.skill_info_examples",
+                    "skill_id": "skill-about.neongeckocom",
+                    "api_method": "skill_info_examples",
+                },
+                {
+                    "help": "\n        Get the current timestamp in seconds since epoch.\n        :param request: Request containing location to get time of\n        :returns: Response containing current timestamp\n        ",
+                    "request_schema": {
+                        "properties": {
+                            "location": {
+                                "anyOf": [
+                                    {"type": "string"},
+                                    {"type": "null"},
+                                ],
+                                "default": None,
+                                "title": "Location",
+                            }
+                        },
+                        "title": "_CurrentTimeRequest",
+                        "type": "object",
+                    },
+                    "response_schema": {
+                        "properties": {
+                            "current_timestamp": {
+                                "title": "Current Timestamp",
+                                "type": "number",
+                            }
+                        },
+                        "required": ["current_timestamp"],
+                        "title": "_CurrentTimeResponse",
+                        "type": "object",
+                    },
+                    "signature": "(request: skill_date_time._CurrentTimeRequest) -> skill_date_time._CurrentTimeResponse",
+                    "type": "skill-date_time.neongeckocom.get_current_time",
+                    "skill_id": "skill-date_time.neongeckocom",
+                    "api_method": "get_current_time",
+                },
             ]
         }
     }

--- a/neon_data_models/models/api/http/neon.py
+++ b/neon_data_models/models/api/http/neon.py
@@ -24,7 +24,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Dict
+from typing import List
 from pydantic import Field, RootModel
 from neon_data_models.models.api.messagebus import (
     NeonSkillApiData,
@@ -33,55 +33,18 @@ from neon_data_models.models.api.messagebus import (
 )
 
 
+class NeonSkillApiHttpData(NeonSkillApiData):
+    skill_id: str = Field(
+            description="ID of the skill providing this API method")
+    api_method: str = Field(
+            description="API method name")
+
 class NeonHttpListSkillApiResponse(RootModel):
-    root: Dict[str, Dict[str, NeonSkillApiData]]
+    root: List[NeonSkillApiHttpData]
 
     model_config = {
         "json_schema_extra": {
             "examples": [
-                {
-                    "skill-about.neongeckocom": {
-                        "skill_info_examples": {
-                            "help": "API method to build a list of skill examples",
-                            "request_schema": None,
-                            "response_schema": None,
-                            "signature": "() -> List[str]",
-                            "type": "skill-about.neongeckocom.skill_info_examples",
-                        }
-                    },
-                    "skill-date_time.neongeckocom": {
-                        "get_current_time": {
-                            "help": "\n        Get the current timestamp in seconds since epoch.\n        :param request: Request containing location to get time of\n        :returns: Response containing current timestamp\n        ",
-                            "request_schema": {
-                                "properties": {
-                                    "location": {
-                                        "anyOf": [
-                                            {"type": "string"},
-                                            {"type": "null"},
-                                        ],
-                                        "default": None,
-                                        "title": "Location",
-                                    }
-                                },
-                                "title": "_CurrentTimeRequest",
-                                "type": "object",
-                            },
-                            "response_schema": {
-                                "properties": {
-                                    "current_timestamp": {
-                                        "title": "Current Timestamp",
-                                        "type": "number",
-                                    }
-                                },
-                                "required": ["current_timestamp"],
-                                "title": "_CurrentTimeResponse",
-                                "type": "object",
-                            },
-                            "signature": "(request: skill_date_time._CurrentTimeRequest) -> skill_date_time._CurrentTimeResponse",
-                            "type": "skill-date_time.neongeckocom.get_current_time",
-                        },
-                    },
-                }
             ]
         }
     }

--- a/neon_data_models/models/api/http/neon.py
+++ b/neon_data_models/models/api/http/neon.py
@@ -40,49 +40,47 @@ class NeonHttpListSkillApiResponse(RootModel):
         "json_schema_extra": {
             "examples": [
                 {
-                    "root": {
-                        "skill-about.neongeckocom": {
-                            "skill_info_examples": {
-                                "help": "API method to build a list of skill examples",
-                                "request_schema": None,
-                                "response_schema": None,
-                                "signature": "() -> List[str]",
-                                "type": "skill-about.neongeckocom.skill_info_examples",
-                            }
-                        },
-                        "skill-date_time.neongeckocom": {
-                            "get_current_time": {
-                                "help": "\n        Get the current timestamp in seconds since epoch.\n        :param request: Request containing location to get time of\n        :returns: Response containing current timestamp\n        ",
-                                "request_schema": {
-                                    "properties": {
-                                        "location": {
-                                            "anyOf": [
-                                                {"type": "string"},
-                                                {"type": "null"},
-                                            ],
-                                            "default": None,
-                                            "title": "Location",
-                                        }
-                                    },
-                                    "title": "_CurrentTimeRequest",
-                                    "type": "object",
+                    "skill-about.neongeckocom": {
+                        "skill_info_examples": {
+                            "help": "API method to build a list of skill examples",
+                            "request_schema": None,
+                            "response_schema": None,
+                            "signature": "() -> List[str]",
+                            "type": "skill-about.neongeckocom.skill_info_examples",
+                        }
+                    },
+                    "skill-date_time.neongeckocom": {
+                        "get_current_time": {
+                            "help": "\n        Get the current timestamp in seconds since epoch.\n        :param request: Request containing location to get time of\n        :returns: Response containing current timestamp\n        ",
+                            "request_schema": {
+                                "properties": {
+                                    "location": {
+                                        "anyOf": [
+                                            {"type": "string"},
+                                            {"type": "null"},
+                                        ],
+                                        "default": None,
+                                        "title": "Location",
+                                    }
                                 },
-                                "response_schema": {
-                                    "properties": {
-                                        "current_timestamp": {
-                                            "title": "Current Timestamp",
-                                            "type": "number",
-                                        }
-                                    },
-                                    "required": ["current_timestamp"],
-                                    "title": "_CurrentTimeResponse",
-                                    "type": "object",
-                                },
-                                "signature": "(request: skill_date_time._CurrentTimeRequest) -> skill_date_time._CurrentTimeResponse",
-                                "type": "skill-date_time.neongeckocom.get_current_time",
+                                "title": "_CurrentTimeRequest",
+                                "type": "object",
                             },
+                            "response_schema": {
+                                "properties": {
+                                    "current_timestamp": {
+                                        "title": "Current Timestamp",
+                                        "type": "number",
+                                    }
+                                },
+                                "required": ["current_timestamp"],
+                                "title": "_CurrentTimeResponse",
+                                "type": "object",
+                            },
+                            "signature": "(request: skill_date_time._CurrentTimeRequest) -> skill_date_time._CurrentTimeResponse",
+                            "type": "skill-date_time.neongeckocom.get_current_time",
                         },
-                    }
+                    },
                 }
             ]
         }

--- a/neon_data_models/models/api/http/neon.py
+++ b/neon_data_models/models/api/http/neon.py
@@ -39,7 +39,7 @@ class NeonHttpListSkillApiResponse(RootModel):
 
 class NeonHttpSkillApiRequest(SkillApiRequestData):
     skill_id: str = Field(description="skill_id being requested")
-    skill_method: str = Field(description="API method being requested")
+    api_method: str = Field(description="API method being requested")
 
 
 class NeonHttpSkillApiResponse(SkillApiResponseData):

--- a/neon_data_models/models/api/http/neon.py
+++ b/neon_data_models/models/api/http/neon.py
@@ -36,16 +36,93 @@ from neon_data_models.models.api.messagebus import (
 class NeonHttpListSkillApiResponse(RootModel):
     root: Dict[str, Dict[str, NeonSkillApiData]]
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "root": {
+                        "skill-about.neongeckocom": {
+                            "skill_info_examples": {
+                                "help": "API method to build a list of skill examples",
+                                "request_schema": None,
+                                "response_schema": None,
+                                "signature": "() -> List[str]",
+                                "type": "skill-about.neongeckocom.skill_info_examples",
+                            }
+                        },
+                        "skill-date_time.neongeckocom": {
+                            "get_current_time": {
+                                "help": "\n        Get the current timestamp in seconds since epoch.\n        :param request: Request containing location to get time of\n        :returns: Response containing current timestamp\n        ",
+                                "request_schema": {
+                                    "properties": {
+                                        "location": {
+                                            "anyOf": [
+                                                {"type": "string"},
+                                                {"type": "null"},
+                                            ],
+                                            "default": None,
+                                            "title": "Location",
+                                        }
+                                    },
+                                    "title": "_CurrentTimeRequest",
+                                    "type": "object",
+                                },
+                                "response_schema": {
+                                    "properties": {
+                                        "current_timestamp": {
+                                            "title": "Current Timestamp",
+                                            "type": "number",
+                                        }
+                                    },
+                                    "required": ["current_timestamp"],
+                                    "title": "_CurrentTimeResponse",
+                                    "type": "object",
+                                },
+                                "signature": "(request: skill_date_time._CurrentTimeRequest) -> skill_date_time._CurrentTimeResponse",
+                                "type": "skill-date_time.neongeckocom.get_current_time",
+                            },
+                        },
+                    }
+                }
+            ]
+        }
+    }
+
 
 class NeonHttpSkillApiRequest(SkillApiRequestData):
     skill_id: str = Field(description="skill_id being requested")
     api_method: str = Field(description="API method being requested")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "skill_id": "skill-about.neongeckocom",
+                    "api_method": "skill_info_examples",
+                    "args": [],
+                    "kwargs": {},
+                }
+            ]
+        }
+    }
 
 
 class NeonHttpSkillApiResponse(SkillApiResponseData):
     """
     Convenience wrapper to implement examples for Swagger UI
     """
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "result": "API Response matching advertised schema",
+                    "error": None,
+                },
+                {"result": None, "error": "API Method error message"},
+            ]
+        }
+    }
 
 
 __all__ = [

--- a/neon_data_models/models/api/http/neon.py
+++ b/neon_data_models/models/api/http/neon.py
@@ -46,47 +46,49 @@ class NeonHttpListSkillApiResponse(RootModel):
     model_config = {
         "json_schema_extra": {
             "examples": [
-                {
-                    "help": "\n        API Method to build a list of examples as listed in skill metadata.\n        ",
-                    "request_schema": None,
-                    "response_schema": None,
-                    "signature": None,
-                    "type": "skill-about.neongeckocom.skill_info_examples",
-                    "skill_id": "skill-about.neongeckocom",
-                    "api_method": "skill_info_examples",
-                },
-                {
-                    "help": "\n        Get the current timestamp in seconds since epoch.\n        :param request: Request containing location to get time of\n        :returns: Response containing current timestamp\n        ",
-                    "request_schema": {
-                        "properties": {
-                            "location": {
-                                "anyOf": [
-                                    {"type": "string"},
-                                    {"type": "null"},
-                                ],
-                                "default": None,
-                                "title": "Location",
-                            }
-                        },
-                        "title": "_CurrentTimeRequest",
-                        "type": "object",
+                [
+                    {
+                        "help": "\n        API Method to build a list of examples as listed in skill metadata.\n        ",
+                        "request_schema": None,
+                        "response_schema": None,
+                        "signature": None,
+                        "type": "skill-about.neongeckocom.skill_info_examples",
+                        "skill_id": "skill-about.neongeckocom",
+                        "api_method": "skill_info_examples",
                     },
-                    "response_schema": {
-                        "properties": {
-                            "current_timestamp": {
-                                "title": "Current Timestamp",
-                                "type": "number",
-                            }
+                    {
+                        "help": "\n        Get the current timestamp in seconds since epoch.\n        :param request: Request containing location to get time of\n        :returns: Response containing current timestamp\n        ",
+                        "request_schema": {
+                            "properties": {
+                                "location": {
+                                    "anyOf": [
+                                        {"type": "string"},
+                                        {"type": "null"},
+                                    ],
+                                    "default": None,
+                                    "title": "Location",
+                                }
+                            },
+                            "title": "_CurrentTimeRequest",
+                            "type": "object",
                         },
-                        "required": ["current_timestamp"],
-                        "title": "_CurrentTimeResponse",
-                        "type": "object",
+                        "response_schema": {
+                            "properties": {
+                                "current_timestamp": {
+                                    "title": "Current Timestamp",
+                                    "type": "number",
+                                }
+                            },
+                            "required": ["current_timestamp"],
+                            "title": "_CurrentTimeResponse",
+                            "type": "object",
+                        },
+                        "signature": "(request: skill_date_time._CurrentTimeRequest) -> skill_date_time._CurrentTimeResponse",
+                        "type": "skill-date_time.neongeckocom.get_current_time",
+                        "skill_id": "skill-date_time.neongeckocom",
+                        "api_method": "get_current_time",
                     },
-                    "signature": "(request: skill_date_time._CurrentTimeRequest) -> skill_date_time._CurrentTimeResponse",
-                    "type": "skill-date_time.neongeckocom.get_current_time",
-                    "skill_id": "skill-date_time.neongeckocom",
-                    "api_method": "get_current_time",
-                },
+                ]
             ]
         }
     }

--- a/neon_data_models/models/api/http/neon.py
+++ b/neon_data_models/models/api/http/neon.py
@@ -25,7 +25,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from typing import Dict
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, RootModel
 from neon_data_models.models.api.messagebus import (
     NeonSkillApiData,
     SkillApiRequestData,
@@ -33,8 +33,8 @@ from neon_data_models.models.api.messagebus import (
 )
 
 
-class NeonHttpListResponse(BaseModel):
-    __root__: Dict[str, Dict[str, NeonSkillApiData]]
+class NeonHttpListResponse(RootModel):
+    root: Dict[str, Dict[str, NeonSkillApiData]]
 
 
 class NeonHttpSkillApiRequest(SkillApiRequestData):

--- a/neon_data_models/models/api/http/neon.py
+++ b/neon_data_models/models/api/http/neon.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_data_models/models/api/http/neon.py
+++ b/neon_data_models/models/api/http/neon.py
@@ -25,7 +25,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from typing import Dict
-from pydantic import BaseModel, Field, RootModel
+from pydantic import Field, RootModel
 from neon_data_models.models.api.messagebus import (
     NeonSkillApiData,
     SkillApiRequestData,
@@ -33,7 +33,7 @@ from neon_data_models.models.api.messagebus import (
 )
 
 
-class NeonHttpListResponse(RootModel):
+class NeonHttpListSkillApiResponse(RootModel):
     root: Dict[str, Dict[str, NeonSkillApiData]]
 
 
@@ -49,7 +49,7 @@ class NeonHttpSkillApiResponse(SkillApiResponseData):
 
 
 __all__ = [
-    NeonHttpListResponse.__name__,
+    NeonHttpListSkillApiResponse.__name__,
     NeonHttpSkillApiRequest.__name__,
     NeonHttpSkillApiResponse.__name__,
 ]

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -247,23 +247,24 @@ class NeonGetSkillsApi(BaseMessage):
     msg_type: Literal["neon.skill_api.get"] = "neon.skill_api.get"
 
 
-class NeonSkillsApiResponse(BaseMessage):
-    class NeonSkillApiData(BaseModel):
-        help: str = Field(description="API Method docstring")
-        request_schema: Optional[dict] = Field(
-            default=None, description="JSON request schema for the API method"
-        )
-        response_schema: Optional[dict] = Field(
-            default=None, description="JSON response schema for the API method"
-        )
-        signature: Optional[str] = Field(
-            default=None, description="Python signature of the API method"
-        )
-        msg_type: str = Field(
-            alias="type",
-            description="Message type associated with this API method",
-        )
+class NeonSkillApiData(BaseModel):
+    help: str = Field(description="API Method docstring")
+    request_schema: Optional[dict] = Field(
+        default=None, description="JSON request schema for the API method"
+    )
+    response_schema: Optional[dict] = Field(
+        default=None, description="JSON response schema for the API method"
+    )
+    signature: Optional[str] = Field(
+        default=None, description="Python signature of the API method"
+    )
+    msg_type: str = Field(
+        alias="type",
+        description="Message type associated with this API method",
+    )
 
+
+class NeonSkillsApiResponse(BaseMessage):
     msg_type: Literal["neon.skill_api.get.response"] = (
         "neon.skill_api.get.response"
     )
@@ -272,13 +273,22 @@ class NeonSkillsApiResponse(BaseMessage):
     )
 
 
-class NeonCallSkillApi(BaseMessage):
-    class SkillApiRequestData(BaseModel):
-        args: List[Any] = Field(default=[], description="Positional arguments")
-        kwargs: Dict[str, Any] = Field(
-            default={}, description="Keyword arguments"
-        )
+class SkillApiRequestData(BaseModel):
+    args: List[Any] = Field(default=[], description="Positional arguments")
+    kwargs: Dict[str, Any] = Field(default={}, description="Keyword arguments")
 
+
+class SkillApiResponseData(BaseModel):
+    result: Any = Field(
+        description="Result of the API method call",
+        default=None,
+    )
+    error: Optional[str] = Field(
+        default=None, description="Error message if the call failed"
+    )
+
+
+class NeonCallSkillApi(BaseMessage):
     msg_type: str = Field(description="Requested API Message type")
     data: SkillApiRequestData = Field(
         default=SkillApiRequestData(),
@@ -287,15 +297,6 @@ class NeonCallSkillApi(BaseMessage):
 
 
 class NeonCallSkillApiResponse(BaseMessage):
-    class SkillApiResponseData(BaseModel):
-        result: Any = Field(
-            description="Result of the API method call",
-            default=None,
-        )
-        error: Optional[str] = Field(
-            default=None, description="Error message if the call failed"
-        )
-
     msg_type: str = Field(description="Requested API response Message type")
     data: SkillApiResponseData = Field(description="API Method response data")
 
@@ -313,4 +314,7 @@ __all__ = [
     NeonSkillsApiResponse.__name__,
     NeonCallSkillApi.__name__,
     NeonCallSkillApiResponse.__name__,
+    SkillApiRequestData.__name__,
+    SkillApiResponseData.__name__,
+    NeonSkillApiData.__name__,
 ]

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -314,7 +314,4 @@ __all__ = [
     NeonSkillsApiResponse.__name__,
     NeonCallSkillApi.__name__,
     NeonCallSkillApiResponse.__name__,
-    SkillApiRequestData.__name__,
-    SkillApiResponseData.__name__,
-    NeonSkillApiData.__name__,
 ]

--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -38,96 +38,109 @@ from neon_data_models.models.base.messagebus import BaseMessage
 # Data models
 class GetTtsData(BaseModel):
     text: str = Field(description="Text to be spoken")
-    lang: str = Field(default="en-us",
-                      description="BCP-47 language code for TTS")
+    lang: str = Field(
+        default="en-us", description="BCP-47 language code for TTS"
+    )
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
     def validate_inputs(cls, values):
         # Ensure input values are normalized to valid field names
-        if hasattr(values, 'model_dump'):
+        if hasattr(values, "model_dump"):
             values = values.model_dump()
-        if 'text' not in values:
-            values['text'] = values.get('utterance')
+        if "text" not in values:
+            values["text"] = values.get("utterance")
         return values
 
 
 class TtsResponse(BaseModel):
     sentence: str = Field(description="Text to be spoken")
     translated: bool = Field(
-        default=False, 
-        description="True if the text has been translated before TTS synthesis")
+        default=False,
+        description="True if the text has been translated before TTS synthesis",
+    )
     phonemes: Optional[str] = Field(
-        default=None, description="Phoneme representation of the sentence")
+        default=None, description="Phoneme representation of the sentence"
+    )
     genders: List[Gender] = Field(
         description="List of genders included in the response `audio` field",
-        deprecated=True)
-    male: Optional[str] = Field(default=None,
-                                 description="Path to audio file in male voice")
+        deprecated=True,
+    )
+    male: Optional[str] = Field(
+        default=None, description="Path to audio file in male voice"
+    )
     female: Optional[str] = Field(
-        default=None, description="Path to audio file in female voice")
+        default=None, description="Path to audio file in female voice"
+    )
     audio: Dict[Gender, str]
-    
-    @model_validator(mode='after')
+
+    @model_validator(mode="after")
     def validate_gender_audio_match(self):
         """Validate that the genders list matches the audio dictionary keys."""
         if not set(self.genders) == set(self.audio.keys()):
             raise ValueError(
                 "All genders listed in 'genders' must have corresponding "
-                "entries in 'audio'")
+                "entries in 'audio'"
+            )
         return self
 
 
 class TtsSpeaker(BaseModel):
     name: str = Field(default="Neon", description="Name of the speaker")
     speaker: Optional[str] = Field(
-        default=None, 
+        default=None,
         description="Deprecated: Use 'name' instead",
-        deprecated=True)
+        deprecated=True,
+    )
     language: str = Field(default="en-us", description="BCP-47 language code")
-    gender: Gender = Field(default="female",
-                          description="Requested or synthesized gender")
+    gender: Gender = Field(
+        default="female", description="Requested or synthesized gender"
+    )
     voice: Optional[str] = Field(
-        default=None, description="Requested or synthesized voice name")
-    
-    @model_validator(mode='before')
+        default=None, description="Requested or synthesized voice name"
+    )
+
+    @model_validator(mode="before")
     @classmethod
     def map_speaker_to_name(cls, values):
-        if hasattr(values, 'model_dump'):
+        if hasattr(values, "model_dump"):
             values = values.model_dump()
-        if 'name' not in values and 'speaker' in values:
-            values['name'] = values['speaker']
+        if "name" not in values and "speaker" in values:
+            values["name"] = values["speaker"]
         return values
 
 
 class TtsReponseData(BaseModel):
     responses: Dict[str, TtsResponse] = Field(
-        description="Dictionary of BCP-47 lang codes to TTS responses")
+        description="Dictionary of BCP-47 lang codes to TTS responses"
+    )
     speaker: Optional[TtsSpeaker] = Field(
-        default=None, description="Optional speaker metadata")
+        default=None, description="Optional speaker metadata"
+    )
 
 
 class GetSttData(BaseModel):
     audio_data: str = Field(description="Base64-encoded audio data")
-    lang: str = Field(default="en-us",
-                      description="BCP-47 language code for STT")
+    lang: str = Field(
+        default="en-us", description="BCP-47 language code for STT"
+    )
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
     def validate_inputs(cls, values):
         # Ensure input values are normalized to valid field names
-        if hasattr(values, 'model_dump'):
+        if hasattr(values, "model_dump"):
             values = values.model_dump()
-        if 'audio_data' not in values:
-            values['audio_data'] = values.get('message_body')
+        if "audio_data" not in values:
+            values["audio_data"] = values.get("message_body")
         return values
 
 
 class SttReponseData(BaseModel):
     transcripts: List[str]
     parser_data: Dict[str, Any]
-    
-    @model_validator(mode='after')
+
+    @model_validator(mode="after")
     def validate_transcripts_not_empty(self):
         """Validate that the transcripts list is not empty."""
         if not self.transcripts:
@@ -137,17 +150,18 @@ class SttReponseData(BaseModel):
 
 class GetResponseData(BaseModel):
     utterances: List[str] = Field(description="List of input utterance(s)")
-    lang: str = Field(default="en-us",
-                      description="BCP-47 language code for input/response")
+    lang: str = Field(
+        default="en-us", description="BCP-47 language code for input/response"
+    )
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
     def validate_inputs(cls, values):
         # Ensure input values are normalized to valid field names
-        if hasattr(values, 'model_dump'):
+        if hasattr(values, "model_dump"):
             values = values.model_dump()
-        if 'utterances' not in values:
-            values['utterances'] = [values.pop('messageText', '')]
+        if "utterances" not in values:
+            values["utterances"] = [values.pop("messageText", "")]
         return values
 
 
@@ -162,7 +176,7 @@ class NeonGetTts(BaseMessage):
     msg_type: Literal["neon.get_tts"] = "neon.get_tts"
     data: GetTtsData
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def ensure_audio_destination(self):
         if "audio" not in self.context.destination:
             self.context.destination = ["audio"]
@@ -173,7 +187,7 @@ class NeonGetStt(BaseMessage):
     msg_type: Literal["neon.get_stt"] = "neon.get_stt"
     data: GetSttData
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def ensure_audio_destination(self):
         if "audio" not in self.context.destination:
             # Default context is not valid for this request, so override it
@@ -182,10 +196,12 @@ class NeonGetStt(BaseMessage):
 
 
 class NeonTextInput(BaseMessage):
-    msg_type: Literal["recognizer_loop:utterance"] = "recognizer_loop:utterance"
+    msg_type: Literal["recognizer_loop:utterance"] = (
+        "recognizer_loop:utterance"
+    )
     data: GetResponseData
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def ensure_skills_destination(self):
         if "skills" not in self.context.destination:
             self.context.destination.append("skills")
@@ -196,7 +212,7 @@ class NeonAudioInput(BaseMessage):
     msg_type: Literal["neon.audio_input"] = "neon.audio_input"
     data: GetSttData
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def ensure_audio_destination(self):
         if "audio" not in self.context.destination:
             # Default context is not valid for this request, so override it
@@ -210,21 +226,91 @@ class NeonSttResponse(BaseMessage):
 
 
 class NeonTtsResponse(BaseMessage):
-    msg_type: Literal["neon.get_tts.response",
-                      "klat.response"] = "neon.get_tts.response"
+    msg_type: Literal["neon.get_tts.response", "klat.response"] = (
+        "neon.get_tts.response"
+    )
     data: TtsReponseData
 
 
 class NeonGetLanguages(BaseMessage):
     msg_type: Literal["neon.languages.get"] = "neon.languages.get"
-    
+
 
 class NeonLanguagesResponse(BaseMessage):
-    msg_type: Literal["neon.languages.get.response"] = "neon.languages.get.response"
+    msg_type: Literal["neon.languages.get.response"] = (
+        "neon.languages.get.response"
+    )
     data: NeonLanguagesData
 
 
-__all__ = [NeonGetTts.__name__, NeonGetStt.__name__, NeonTextInput.__name__,
-           NeonAudioInput.__name__, NeonSttResponse.__name__,
-           NeonTtsResponse.__name__, NeonGetLanguages.__name__,
-           NeonLanguagesResponse.__name__]
+class NeonGetSkillsApi(BaseMessage):
+    msg_type: Literal["neon.skill_api.get"] = "neon.skill_api.get"
+
+
+class NeonSkillsApiResponse(BaseMessage):
+    class NeonSkillApiData(BaseModel):
+        help: str = Field(description="API Method docstring")
+        request_schema: Optional[dict] = Field(
+            default=None, description="JSON request schema for the API method"
+        )
+        response_schema: Optional[dict] = Field(
+            default=None, description="JSON response schema for the API method"
+        )
+        signature: Optional[str] = Field(
+            default=None, description="Python signature of the API method"
+        )
+        msg_type: str = Field(
+            alias="type",
+            description="Message type associated with this API method",
+        )
+
+    msg_type: Literal["neon.skill_api.get.response"] = (
+        "neon.skill_api.get.response"
+    )
+    data: Dict[str, Dict[str, NeonSkillApiData]] = Field(
+        description="Dict of skill_id to API methods"
+    )
+
+
+class NeonCallSkillApi(BaseMessage):
+    class SkillApiRequestData(BaseModel):
+        args: List[Any] = Field(default=[], description="Positional arguments")
+        kwargs: Dict[str, Any] = Field(
+            default={}, description="Keyword arguments"
+        )
+
+    msg_type: str = Field(description="Requested API Message type")
+    data: SkillApiRequestData = Field(
+        default=SkillApiRequestData(),
+        description="Data for the API method call",
+    )
+
+
+class NeonCallSkillApiResponse(BaseMessage):
+    class SkillApiResponseData(BaseModel):
+        result: Any = Field(
+            description="Result of the API method call",
+            default=None,
+        )
+        error: Optional[str] = Field(
+            default=None, description="Error message if the call failed"
+        )
+
+    msg_type: str = Field(description="Requested API response Message type")
+    data: SkillApiResponseData = Field(description="API Method response data")
+
+
+__all__ = [
+    NeonGetTts.__name__,
+    NeonGetStt.__name__,
+    NeonTextInput.__name__,
+    NeonAudioInput.__name__,
+    NeonSttResponse.__name__,
+    NeonTtsResponse.__name__,
+    NeonGetLanguages.__name__,
+    NeonLanguagesResponse.__name__,
+    NeonGetSkillsApi.__name__,
+    NeonSkillsApiResponse.__name__,
+    NeonCallSkillApi.__name__,
+    NeonCallSkillApiResponse.__name__,
+]

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -187,7 +187,9 @@ class NeonMqCallSkillApi(NeonCallSkillApi, MQContext):
 
 class NeonMqCallSkillApiResponse(NeonCallSkillApiResponse, MQContext):
     """
-    Data model for an MQ message containing a skill API response
+    Data model for an MQ message containing a skill API response.
+    Note that `msg_type` is overridden from the internal API-specific value
+    to a generic type for MQ routing.
     """
     msg_type: Literal["neon.skill_api.response"] = Field(
         default="neon.skill_api.response",

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -138,12 +138,14 @@ class NeonMqCallSkillApi(NeonCallSkillApi, MQContext):
     """
     Data model for an MQ message calling a skill API
     """
+    # TODO: This doesn't have a known message type, so it cannot be used with the descriminator
 
 
 class NeonMqCallSkillApiResponse(NeonCallSkillApiResponse, MQContext):
     """
     Data model for an MQ message containing a skill API response
     """
+    # TODO: This doesn't have a known message type, so it cannot be used with the descriminator
 
 
 class NeonMqUnknownMessage(BaseMessage, MQContext):
@@ -162,8 +164,8 @@ class NeonApiMessage:
                                      NeonMqTextInput, NeonMqSttResponse,
                                      NeonMqTtsResponse, NeonMqGetLanguages,
                                      NeonMqLanguagesResponse, NeonMqGetSkillsApi,
-                                     NeonMqSkillsApiResponse, NeonMqCallSkillApi,
-                                     NeonMqCallSkillApiResponse],
+                                     NeonMqSkillsApiResponse, 
+                                     ],
                                Field(discriminator='msg_type')])
 
     @classmethod

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -25,55 +25,75 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from typing import Annotated, List, Literal, Union
+from ovos_bus_client.message import Message
 from pydantic import Field, TypeAdapter, model_validator
 
 from neon_data_models.models.base import BaseModel
-from neon_data_models.models.base.contexts import KlatContext, MQContext, \
-    SessionContext, TimingContext
+from neon_data_models.models.base.contexts import (
+    KlatContext,
+    MQContext,
+    SessionContext,
+    TimingContext,
+)
 from neon_data_models.models.base.messagebus import BaseMessage, MessageContext
 from neon_data_models.models.user.neon_profile import UserProfile
-from neon_data_models.models.api.messagebus import NeonGetLanguages, NeonGetTts, NeonGetStt, \
-    NeonAudioInput, NeonLanguagesResponse, NeonTextInput, NeonSttResponse, NeonTtsResponse, \
-    NeonGetSkillsApi, NeonSkillsApiResponse, NeonCallSkillApi, NeonCallSkillApiResponse
+from neon_data_models.models.api.messagebus import (
+    NeonGetLanguages,
+    NeonGetTts,
+    NeonGetStt,
+    NeonAudioInput,
+    NeonLanguagesResponse,
+    NeonTextInput,
+    NeonSttResponse,
+    NeonTtsResponse,
+    NeonGetSkillsApi,
+    NeonSkillsApiResponse,
+    NeonCallSkillApi,
+    NeonCallSkillApiResponse,
+)
 
 
 class GetTtsData(BaseModel):
     text: str = Field(description="Text to be spoken")
-    lang: str = Field(default="en-us",
-                      description="BCP-47 language code for TTS")
+    lang: str = Field(
+        default="en-us", description="BCP-47 language code for TTS"
+    )
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
     def validate_inputs(cls, values):
-        if 'text' not in values:
-            values['text'] = values.pop('utterance', None)
+        if "text" not in values:
+            values["text"] = values.pop("utterance", None)
         return values
 
 
 class GetSttData(BaseModel):
     audio_data: str = Field(description="Base64-encoded audio data")
-    lang: str = Field(default="en-us",
-                      description="BCP-47 language code for STT")
+    lang: str = Field(
+        default="en-us", description="BCP-47 language code for STT"
+    )
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
     def validate_inputs(cls, values):
-        if 'audio_data' not in values:
-            values['audio_data'] = values.get('message_body')
+        if "audio_data" not in values:
+            values["audio_data"] = values.get("message_body")
         return values
 
 
 class GetResponseData(BaseModel):
     utterances: List[str] = Field(description="List of input utterance(s)")
-    lang: str = Field(default="en-us",
-                      description="BCP-47 language code for input/response")
+    lang: str = Field(
+        default="en-us", description="BCP-47 language code for input/response"
+    )
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
     def validate_inputs(cls, values):
-        if 'utterances' not in values:
-            values['utterances'] = [values.pop('messageText', '')]
+        if "utterances" not in values:
+            values["utterances"] = [values.pop("messageText", "")]
         return values
+
 
 class NeonMqGetTts(NeonGetTts, MQContext):
     """
@@ -134,18 +154,44 @@ class NeonMqSkillsApiResponse(NeonSkillsApiResponse, MQContext):
     Data model for an MQ message containing available skill APIs
     """
 
+
 class NeonMqCallSkillApi(NeonCallSkillApi, MQContext):
     """
     Data model for an MQ message calling a skill API
     """
-    # TODO: This doesn't have a known message type, so it cannot be used with the descriminator
 
+    class _RequestData(NeonCallSkillApi.SkillApiRequestData):
+        msg_type: str = Field(
+            description="Message type associated with the specific API requested"
+        )
+
+    msg_type: Literal["neon.skill_api.query"] = Field(
+        default="neon.skill_api.query",
+        description="Message type for skill API calls",
+    )
+    data: _RequestData = Field(
+        description="API request data including `msg_type` and call params"
+    )
+
+    def as_messagebus_message(self) -> Message:
+        """
+        Override default Message translation to account for `msg_type` being
+        specified in request data
+        """
+        return Message(
+            msg_type=self.data.msg_type,
+            data={"args": self.data.args, "kwargs": self.data.kwargs},
+            context=self.context.model_dump()
+            )
 
 class NeonMqCallSkillApiResponse(NeonCallSkillApiResponse, MQContext):
     """
     Data model for an MQ message containing a skill API response
     """
-    # TODO: This doesn't have a known message type, so it cannot be used with the descriminator
+    msg_type: Literal["neon.skill_api.response"] = Field(
+        default="neon.skill_api.response",
+        description="Message type for skill API responses",
+    )
 
 
 class NeonMqUnknownMessage(BaseMessage, MQContext):
@@ -160,23 +206,35 @@ class NeonApiMessage:
     Type adapter for validating an arbitrary MQ message. This will always return
     an instance that extends `BaseMessage` and `MQContext`.
     """
-    ta = TypeAdapter(Annotated[Union[NeonMqGetStt, NeonMqGetTts,
-                                     NeonMqTextInput, NeonMqSttResponse,
-                                     NeonMqTtsResponse, NeonMqGetLanguages,
-                                     NeonMqLanguagesResponse, NeonMqGetSkillsApi,
-                                     NeonMqSkillsApiResponse, 
-                                     ],
-                               Field(discriminator='msg_type')])
+
+    ta = TypeAdapter(
+        Annotated[
+            Union[
+                NeonMqGetStt,
+                NeonMqGetTts,
+                NeonMqTextInput,
+                NeonMqSttResponse,
+                NeonMqTtsResponse,
+                NeonMqGetLanguages,
+                NeonMqLanguagesResponse,
+                NeonMqGetSkillsApi,
+                NeonMqSkillsApiResponse,
+                NeonMqCallSkillApi,
+                NeonMqCallSkillApiResponse,
+            ],
+            Field(discriminator="msg_type"),
+        ]
+    )
 
     @classmethod
     def __new__(cls, *args, **kwargs) -> BaseMessage:
         # Parse the MQ Context from a `Message` input to create a proper API message
-        if 'message_id' not in kwargs:
+        if "message_id" not in kwargs:
             # Extract MQ context data from the message
-            mq_data = kwargs.get('context', {}).get('mq', {})
+            mq_data = kwargs.get("context", {}).get("mq", {})
             # Update values with MQ context data
             kwargs.update(mq_data)
-        
+
         try:
             return cls.ta.validate_python(kwargs)
         except Exception as e:
@@ -188,40 +246,61 @@ class NeonApiMessage:
         """
         Parse a Klat SocketIO message into a valid MQ API message
         """
-        requested_service = sio_message.get("requested_skill",
-                                         "recognizer").lower()
+        requested_service = sio_message.get(
+            "requested_skill", "recognizer"
+        ).lower()
         if requested_service not in ["stt", "tts", "recognizer"]:
-            raise ValueError(f"Invalid requested service '{requested_service}'")
+            raise ValueError(
+                f"Invalid requested service '{requested_service}'"
+            )
         klat_context = KlatContext(**sio_message)
         mq_context = MQContext(**sio_message)
-        context = MessageContext(source="mq_api",
-                                 client=sio_message.get("client", "unknown"),
-                                 username=sio_message.get("nick", "guest"),
-                                 klat_data=klat_context, mq=mq_context,
-                                 user_profiles=[UserProfile()],
-                                 session=SessionContext(
-                                     session_id=sio_message.get("cid", "klat")),
-                                 timing=TimingContext(
-                                     client_sent=sio_message.get("timeCreated"))
+        context = MessageContext(
+            source="mq_api",
+            client=sio_message.get("client", "unknown"),
+            username=sio_message.get("nick", "guest"),
+            klat_data=klat_context,
+            mq=mq_context,
+            user_profiles=[UserProfile()],
+            session=SessionContext(session_id=sio_message.get("cid", "klat")),
+            timing=TimingContext(client_sent=sio_message.get("timeCreated")),
         )
         if requested_service == "stt":
             context.destination = ["speech"]
-            return NeonMqGetStt(data=GetSttData(**sio_message), context=context,
-                              **mq_context.model_dump())
+            return NeonMqGetStt(
+                data=GetSttData(**sio_message),
+                context=context,
+                **mq_context.model_dump(),
+            )
         elif requested_service == "tts":
             context.destination = ["audio"]
-            return NeonMqGetTts(data=GetTtsData(**sio_message), context=context,
-                              **mq_context.model_dump())
+            return NeonMqGetTts(
+                data=GetTtsData(**sio_message),
+                context=context,
+                **mq_context.model_dump(),
+            )
         elif requested_service == "recognizer":
             context.destination = ["skills"]
-            return NeonMqTextInput(data=GetResponseData(**sio_message),
-                                   context=context, **mq_context.model_dump())
+            return NeonMqTextInput(
+                data=GetResponseData(**sio_message),
+                context=context,
+                **mq_context.model_dump(),
+            )
 
 
-__all__ = [NeonMqGetTts.__name__, NeonMqGetStt.__name__, 
-           NeonMqTextInput.__name__, NeonMqAudioInput.__name__,
-           NeonMqSttResponse.__name__, NeonMqTtsResponse.__name__,
-           NeonMqGetLanguages.__name__, NeonMqLanguagesResponse.__name__,
-           NeonApiMessage.__name__, NeonMqGetSkillsApi.__name__,
-           NeonMqSkillsApiResponse.__name__, NeonMqCallSkillApi.__name__,
-           NeonMqCallSkillApiResponse.__name__, NeonMqUnknownMessage.__name__]
+__all__ = [
+    NeonMqGetTts.__name__,
+    NeonMqGetStt.__name__,
+    NeonMqTextInput.__name__,
+    NeonMqAudioInput.__name__,
+    NeonMqSttResponse.__name__,
+    NeonMqTtsResponse.__name__,
+    NeonMqGetLanguages.__name__,
+    NeonMqLanguagesResponse.__name__,
+    NeonApiMessage.__name__,
+    NeonMqGetSkillsApi.__name__,
+    NeonMqSkillsApiResponse.__name__,
+    NeonMqCallSkillApi.__name__,
+    NeonMqCallSkillApiResponse.__name__,
+    NeonMqUnknownMessage.__name__,
+]

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -33,7 +33,8 @@ from neon_data_models.models.base.contexts import KlatContext, MQContext, \
 from neon_data_models.models.base.messagebus import BaseMessage, MessageContext
 from neon_data_models.models.user.neon_profile import UserProfile
 from neon_data_models.models.api.messagebus import NeonGetLanguages, NeonGetTts, NeonGetStt, \
-    NeonAudioInput, NeonLanguagesResponse, NeonTextInput, NeonSttResponse, NeonTtsResponse
+    NeonAudioInput, NeonLanguagesResponse, NeonTextInput, NeonSttResponse, NeonTtsResponse, \
+    NeonGetSkillsApi, NeonSkillsApiResponse, NeonCallSkillApi, NeonCallSkillApiResponse
 
 
 class GetTtsData(BaseModel):
@@ -122,6 +123,29 @@ class NeonMqLanguagesResponse(NeonLanguagesResponse, MQContext):
     """
 
 
+class NeonMqGetSkillsApi(NeonGetSkillsApi, MQContext):
+    """
+    Data model for an MQ message requesting available skill APIs
+    """
+
+
+class NeonMqSkillsApiResponse(NeonSkillsApiResponse, MQContext):
+    """
+    Data model for an MQ message containing available skill APIs
+    """
+
+class NeonMqCallSkillApi(NeonCallSkillApi, MQContext):
+    """
+    Data model for an MQ message calling a skill API
+    """
+
+
+class NeonMqCallSkillApiResponse(NeonCallSkillApiResponse, MQContext):
+    """
+    Data model for an MQ message containing a skill API response
+    """
+
+
 class NeonMqUnknownMessage(BaseMessage, MQContext):
     """
     Default message class for validating Messagebus messages that should be
@@ -137,7 +161,9 @@ class NeonApiMessage:
     ta = TypeAdapter(Annotated[Union[NeonMqGetStt, NeonMqGetTts,
                                      NeonMqTextInput, NeonMqSttResponse,
                                      NeonMqTtsResponse, NeonMqGetLanguages,
-                                     NeonMqLanguagesResponse],
+                                     NeonMqLanguagesResponse, NeonMqGetSkillsApi,
+                                     NeonMqSkillsApiResponse, NeonMqCallSkillApi,
+                                     NeonMqCallSkillApiResponse],
                                Field(discriminator='msg_type')])
 
     @classmethod
@@ -194,4 +220,6 @@ __all__ = [NeonMqGetTts.__name__, NeonMqGetStt.__name__,
            NeonMqTextInput.__name__, NeonMqAudioInput.__name__,
            NeonMqSttResponse.__name__, NeonMqTtsResponse.__name__,
            NeonMqGetLanguages.__name__, NeonMqLanguagesResponse.__name__,
-           NeonApiMessage.__name__, NeonMqUnknownMessage.__name__]
+           NeonApiMessage.__name__, NeonMqGetSkillsApi.__name__,
+           NeonMqSkillsApiResponse.__name__, NeonMqCallSkillApi.__name__,
+           NeonMqCallSkillApiResponse.__name__, NeonMqUnknownMessage.__name__]

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -165,8 +165,8 @@ class NeonMqCallSkillApi(NeonCallSkillApi, MQContext):
             description="Message type associated with the specific API requested"
         )
 
-    msg_type: Literal["neon.skill_api.query"] = Field(
-        default="neon.skill_api.query",
+    msg_type: Literal["neon.skill_api.call"] = Field(
+        default="neon.skill_api.call",
         description="Message type for skill API calls",
     )
     data: _RequestData = Field(

--- a/neon_data_models/models/api/mq/neon.py
+++ b/neon_data_models/models/api/mq/neon.py
@@ -50,6 +50,7 @@ from neon_data_models.models.api.messagebus import (
     NeonSkillsApiResponse,
     NeonCallSkillApi,
     NeonCallSkillApiResponse,
+    SkillApiRequestData
 )
 
 
@@ -160,7 +161,7 @@ class NeonMqCallSkillApi(NeonCallSkillApi, MQContext):
     Data model for an MQ message calling a skill API
     """
 
-    class _RequestData(NeonCallSkillApi.SkillApiRequestData):
+    class _RequestData(SkillApiRequestData):
         msg_type: str = Field(
             description="Message type associated with the specific API requested"
         )

--- a/tests/models/api/test_http.py
+++ b/tests/models/api/test_http.py
@@ -193,3 +193,238 @@ class TestBrainForgeHttp(TestCase):
             response.choices[0]["message"]["content"], llm_response.response
         )
 
+
+class TestNeonHttp(TestCase):
+    def test_neon_skill_api_http_data(self):
+        from neon_data_models.models.api.http.neon import NeonSkillApiHttpData
+
+        # Valid data with all fields
+        valid_data = NeonSkillApiHttpData(
+            skill_id="skill-about.neongeckocom",
+            api_method="skill_info_examples",
+            help="API Method to build a list of examples",
+            request_schema=None,
+            response_schema=None,
+            signature=None,
+            msg_type="skill-about.neongeckocom.skill_info_examples",
+        )
+        self.assertEqual(valid_data.skill_id, "skill-about.neongeckocom")
+        self.assertEqual(valid_data.api_method, "skill_info_examples")
+        self.assertEqual(valid_data.help, "API Method to build a list of examples")
+        self.assertEqual(
+            valid_data.msg_type, "skill-about.neongeckocom.skill_info_examples"
+        )
+
+        # Valid data with schema
+        valid_data_with_schema = NeonSkillApiHttpData(
+            skill_id="skill-date_time.neongeckocom",
+            api_method="get_current_time",
+            help="Get the current timestamp in seconds since epoch.",
+            request_schema={
+                "properties": {
+                    "location": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                        "title": "Location",
+                    }
+                },
+                "title": "_CurrentTimeRequest",
+                "type": "object",
+            },
+            response_schema={
+                "properties": {
+                    "current_timestamp": {
+                        "title": "Current Timestamp",
+                        "type": "number",
+                    }
+                },
+                "required": ["current_timestamp"],
+                "title": "_CurrentTimeResponse",
+                "type": "object",
+            },
+            signature="(request: skill_date_time._CurrentTimeRequest) -> skill_date_time._CurrentTimeResponse",
+            msg_type="skill-date_time.neongeckocom.get_current_time",
+        )
+        self.assertIsInstance(valid_data_with_schema.request_schema, dict)
+        self.assertIsInstance(valid_data_with_schema.response_schema, dict)
+        self.assertIsInstance(valid_data_with_schema.signature, str)
+
+        # Invalid data (missing required fields)
+        with self.assertRaises(ValidationError):
+            NeonSkillApiHttpData(
+                skill_id="test_skill",
+                # Missing api_method
+                help="Test help",
+            )
+
+    def test_neon_http_list_skill_api_response(self):
+        from neon_data_models.models.api.http.neon import (
+            NeonHttpListSkillApiResponse,
+            NeonSkillApiHttpData,
+        )
+
+        # Valid response with multiple items
+        valid_response = NeonHttpListSkillApiResponse(
+            root=[
+                NeonSkillApiHttpData(
+                    skill_id="skill-about.neongeckocom",
+                    api_method="skill_info_examples",
+                    help="API Method to build a list of examples",
+                    request_schema=None,
+                    response_schema=None,
+                    signature=None,
+                    msg_type="skill-about.neongeckocom.skill_info_examples",
+                ),
+                NeonSkillApiHttpData(
+                    skill_id="skill-date_time.neongeckocom",
+                    api_method="get_current_time",
+                    help="Get the current timestamp in seconds since epoch.",
+                    request_schema={
+                        "properties": {
+                            "location": {
+                                "anyOf": [{"type": "string"}, {"type": "null"}],
+                                "default": None,
+                                "title": "Location",
+                            }
+                        },
+                        "title": "_CurrentTimeRequest",
+                        "type": "object",
+                    },
+                    response_schema={
+                        "properties": {
+                            "current_timestamp": {
+                                "title": "Current Timestamp",
+                                "type": "number",
+                            }
+                        },
+                        "required": ["current_timestamp"],
+                        "title": "_CurrentTimeResponse",
+                        "type": "object",
+                    },
+                    signature="(request: skill_date_time._CurrentTimeRequest) -> skill_date_time._CurrentTimeResponse",
+                    msg_type="skill-date_time.neongeckocom.get_current_time",
+                ),
+            ]
+        )
+        self.assertEqual(len(valid_response.root), 2)
+        self.assertIsInstance(valid_response.root[0], NeonSkillApiHttpData)
+        self.assertEqual(
+            valid_response.root[0].skill_id, "skill-about.neongeckocom"
+        )
+        self.assertEqual(
+            valid_response.root[1].skill_id, "skill-date_time.neongeckocom"
+        )
+
+        # Valid empty response
+        empty_response = NeonHttpListSkillApiResponse(root=[])
+        self.assertEqual(len(empty_response.root), 0)
+
+        # Test serialization/deserialization
+        data = valid_response.model_dump()
+        # For RootModel, the data is a list, so we create directly from the list
+        reconstructed = NeonHttpListSkillApiResponse(root=data)
+        self.assertEqual(len(reconstructed.root), 2)
+        self.assertEqual(
+            reconstructed.root[0].skill_id, "skill-about.neongeckocom"
+        )
+        with self.assertRaises(ValidationError):
+            # Invalid, empty response
+            NeonHttpListSkillApiResponse(root=None)
+
+        with self.assertRaises(ValidationError):
+            # Invalid type
+            NeonHttpListSkillApiResponse(root={})
+
+    def test_neon_http_skill_api_request(self):
+        from neon_data_models.models.api.http.neon import NeonHttpSkillApiRequest
+
+        # Valid request with no args/kwargs
+        valid_request = NeonHttpSkillApiRequest(
+            skill_id="skill-about.neongeckocom",
+            api_method="skill_info_examples",
+        )
+        self.assertEqual(valid_request.skill_id, "skill-about.neongeckocom")
+        self.assertEqual(valid_request.api_method, "skill_info_examples")
+        self.assertEqual(valid_request.args, [])
+        self.assertEqual(valid_request.kwargs, {})
+
+        # Valid request with args and kwargs
+        valid_request_with_data = NeonHttpSkillApiRequest(
+            skill_id="skill-date_time.neongeckocom",
+            api_method="get_current_time",
+            args=["arg1", "arg2"],
+            kwargs={"location": "Seattle", "timezone": "UTC"},
+        )
+        self.assertEqual(valid_request_with_data.args, ["arg1", "arg2"])
+        self.assertEqual(
+            valid_request_with_data.kwargs,
+            {"location": "Seattle", "timezone": "UTC"},
+        )
+
+        # Invalid request (missing required fields)
+        with self.assertRaises(ValidationError):
+            NeonHttpSkillApiRequest(
+                skill_id="test_skill",
+                # Missing api_method
+            )
+
+        with self.assertRaises(ValidationError):
+            NeonHttpSkillApiRequest(
+                # Missing skill_id
+                api_method="test_method",
+            )
+
+    def test_neon_http_skill_api_response(self):
+        from neon_data_models.models.api.http.neon import NeonHttpSkillApiResponse
+
+        # Valid response with result
+        valid_response_with_result = NeonHttpSkillApiResponse(
+            result="API Response matching advertised schema",
+            error=None,
+        )
+        self.assertEqual(
+            valid_response_with_result.result,
+            "API Response matching advertised schema",
+        )
+        self.assertIsNone(valid_response_with_result.error)
+
+        # Valid response with error
+        valid_response_with_error = NeonHttpSkillApiResponse(
+            result=None, error="API Method error message"
+        )
+        self.assertIsNone(valid_response_with_error.result)
+        self.assertEqual(
+            valid_response_with_error.error, "API Method error message"
+        )
+
+        # Valid response with complex result
+        complex_result = {
+            "timestamp": 1640995200.0,
+            "timezone": "UTC",
+            "formatted_time": "2022-01-01 00:00:00",
+        }
+        valid_response_complex = NeonHttpSkillApiResponse(
+            result=complex_result, error=None
+        )
+        self.assertEqual(valid_response_complex.result, complex_result)
+        self.assertIsNone(valid_response_complex.error)
+
+        # Valid response with list result
+        list_result = ["item1", "item2", "item3"]
+        valid_response_list = NeonHttpSkillApiResponse(
+            result=list_result, error=None
+        )
+        self.assertEqual(valid_response_list.result, list_result)
+
+        # Valid response with both result and error (should be allowed)
+        both_fields_response = NeonHttpSkillApiResponse(
+            result="some result", error="some error"
+        )
+        self.assertEqual(both_fields_response.result, "some result")
+        self.assertEqual(both_fields_response.error, "some error")
+
+        # Test serialization/deserialization
+        response_data = valid_response_complex.model_dump()
+        reconstructed = NeonHttpSkillApiResponse(**response_data)
+        self.assertEqual(reconstructed.result, complex_result)
+        self.assertIsNone(reconstructed.error)

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -717,3 +717,394 @@ class TestMessagebusModels(TestCase):
         }
         stt_response = SttReponseData(**valid_empty_parser)
         self.assertEqual(len(stt_response.parser_data), 0)
+
+    def test_neon_get_skills_api(self):
+        from neon_data_models.models.api.messagebus import NeonGetSkillsApi
+        from neon_data_models.models.base.messagebus import BaseMessage
+
+        # Test valid message
+        valid_message = NeonGetSkillsApi(data={}, context={})
+        self.assertIsInstance(valid_message, NeonGetSkillsApi)
+        self.assertIsInstance(valid_message, BaseMessage)
+        self.assertEqual(valid_message.msg_type, "neon.skill_api.get")
+        self.assertEqual(valid_message.data, {})
+
+        # Test with custom context
+        context_data = {"source": "test_client", "destination": ["skills"]}
+        message_with_context = NeonGetSkillsApi(data={}, context=context_data)
+        self.assertEqual(message_with_context.context.source, "test_client")
+        self.assertEqual(message_with_context.context.destination, ["skills"])
+
+        # Test with invalid msg_type (should fail due to Literal constraint)
+        with self.assertRaises(ValidationError):
+            NeonGetSkillsApi(data={}, context={}, msg_type="invalid.type")
+
+    def test_neon_skill_api_data(self):
+        from neon_data_models.models.api.messagebus import NeonSkillApiData
+
+        # Test valid data with all fields
+        valid_data = {
+            "help": "Get the current timestamp in seconds since epoch.",
+            "request_schema": {
+                "properties": {
+                    "location": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                        "title": "Location",
+                    }
+                },
+                "title": "_CurrentTimeRequest",
+                "type": "object",
+            },
+            "response_schema": {
+                "properties": {
+                    "current_timestamp": {
+                        "title": "Current Timestamp",
+                        "type": "number",
+                    }
+                },
+                "required": ["current_timestamp"],
+                "title": "_CurrentTimeResponse",
+                "type": "object",
+            },
+            "signature": "(request: skill_date_time._CurrentTimeRequest) -> skill_date_time._CurrentTimeResponse",
+            "type": "skill-date_time.neongeckocom.get_current_time",
+        }
+        skill_api_data = NeonSkillApiData(**valid_data)
+        self.assertIsInstance(skill_api_data, NeonSkillApiData)
+        self.assertEqual(skill_api_data.help, "Get the current timestamp in seconds since epoch.")
+        self.assertEqual(skill_api_data.msg_type, "skill-date_time.neongeckocom.get_current_time")
+        self.assertIsInstance(skill_api_data.request_schema, dict)
+        self.assertIsInstance(skill_api_data.response_schema, dict)
+        self.assertIsNotNone(skill_api_data.signature)
+
+        # Test valid data with minimal fields (only required fields)
+        minimal_data = {
+            "help": "Simple API method",
+            "type": "test.skill.method"
+        }
+        minimal_skill_api = NeonSkillApiData(**minimal_data)
+        self.assertEqual(minimal_skill_api.help, "Simple API method")
+        self.assertEqual(minimal_skill_api.msg_type, "test.skill.method")
+        self.assertIsNone(minimal_skill_api.request_schema)
+        self.assertIsNone(minimal_skill_api.response_schema)
+        self.assertIsNone(minimal_skill_api.signature)
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            NeonSkillApiData(help="Missing type field")
+        
+        with self.assertRaises(ValidationError):
+            NeonSkillApiData(type="missing.help.field")
+
+    def test_neon_skills_api_response(self):
+        from neon_data_models.models.api.messagebus import NeonSkillsApiResponse, NeonSkillApiData
+        from neon_data_models.models.base.messagebus import BaseMessage
+
+        # Test valid response with multiple skills
+        skill1_data = NeonSkillApiData(
+            help="Get current time",
+            msg_type="skill-date_time.neongeckocom.get_current_time",
+            request_schema={"type": "object"},
+            response_schema={"type": "object"}
+        )
+        skill2_data = NeonSkillApiData(
+            help="Get weather info",
+            msg_type="skill-weather.neongeckocom.get_weather"
+        )
+        
+        response_data = {
+            "skill-date_time.neongeckocom": {
+                "get_current_time": skill1_data
+            },
+            "skill-weather.neongeckocom": {
+                "get_weather": skill2_data
+            }
+        }
+        
+        valid_response = NeonSkillsApiResponse(data=response_data, context={})
+        self.assertIsInstance(valid_response, NeonSkillsApiResponse)
+        self.assertIsInstance(valid_response, BaseMessage)
+        self.assertEqual(valid_response.msg_type, "neon.skill_api.get.response")
+        self.assertEqual(len(valid_response.data), 2)
+        self.assertIn("skill-date_time.neongeckocom", valid_response.data)
+        self.assertIn("skill-weather.neongeckocom", valid_response.data)
+        self.assertEqual(
+            valid_response.data["skill-date_time.neongeckocom"]["get_current_time"].help,
+            "Get current time"
+        )
+
+        # Test empty response
+        empty_response = NeonSkillsApiResponse(data={}, context={})
+        self.assertEqual(len(empty_response.data), 0)
+
+        # Test response with complex nested structure
+        complex_skill_data = {
+            "skill-complex.test": {
+                "method1": NeonSkillApiData(help="Method 1", msg_type="test.method1"),
+                "method2": NeonSkillApiData(help="Method 2", msg_type="test.method2"),
+                "method3": NeonSkillApiData(help="Method 3", msg_type="test.method3")
+            }
+        }
+        complex_response = NeonSkillsApiResponse(data=complex_skill_data, context={})
+        self.assertEqual(len(complex_response.data["skill-complex.test"]), 3)
+        self.assertIn("method2", complex_response.data["skill-complex.test"])
+
+        # Test missing required fields
+        with self.assertRaises(ValidationError):
+            NeonSkillsApiResponse(context={})
+    
+    def test_skill_api_request_data(self):
+        from neon_data_models.models.api.messagebus import SkillApiRequestData
+
+        # Test valid data with no args/kwargs
+        valid_request = SkillApiRequestData()
+        self.assertIsInstance(valid_request, SkillApiRequestData)
+        self.assertEqual(valid_request.args, [])
+        self.assertEqual(valid_request.kwargs, {})
+
+        # Test valid data with args and kwargs
+        valid_request_with_data = SkillApiRequestData(
+            args=["arg1", "arg2", 123],
+            kwargs={"location": "Seattle", "timezone": "UTC", "verbose": True}
+        )
+        self.assertEqual(valid_request_with_data.args, ["arg1", "arg2", 123])
+        self.assertEqual(
+            valid_request_with_data.kwargs,
+            {"location": "Seattle", "timezone": "UTC", "verbose": True}
+        )
+
+        # Test with complex args and kwargs
+        complex_request = SkillApiRequestData(
+            args=[
+                {"nested": "dict"},
+                ["list", "of", "items"],
+                42,
+                True,
+                None
+            ],
+            kwargs={
+                "nested_dict": {"key": "value", "number": 123},
+                "nested_list": [1, 2, 3],
+                "boolean": False,
+                "null_value": None
+            }
+        )
+        self.assertIsInstance(complex_request.args[0], dict)
+        self.assertIsInstance(complex_request.args[1], list)
+        self.assertEqual(complex_request.kwargs["nested_dict"]["number"], 123)
+
+        # Test with empty lists/dicts
+        empty_request = SkillApiRequestData(args=[], kwargs={})
+        self.assertEqual(len(empty_request.args), 0)
+        self.assertEqual(len(empty_request.kwargs), 0)
+
+    def test_skill_api_response_data(self):
+        from neon_data_models.models.api.messagebus import SkillApiResponseData
+
+        # Test valid response with result
+        valid_response_with_result = SkillApiResponseData(
+            result="API Response matching advertised schema",
+            error=None
+        )
+        self.assertEqual(
+            valid_response_with_result.result,
+            "API Response matching advertised schema"
+        )
+        self.assertIsNone(valid_response_with_result.error)
+
+        # Test valid response with error
+        valid_response_with_error = SkillApiResponseData(
+            result=None,
+            error="API Method error message"
+        )
+        self.assertIsNone(valid_response_with_error.result)
+        self.assertEqual(valid_response_with_error.error, "API Method error message")
+
+        # Test valid response with complex result
+        complex_result = {
+            "timestamp": 1640995200.0,
+            "timezone": "UTC",
+            "formatted_time": "2022-01-01 00:00:00",
+            "metadata": {
+                "source": "system_clock",
+                "accuracy": "high"
+            }
+        }
+        valid_response_complex = SkillApiResponseData(result=complex_result)
+        self.assertEqual(valid_response_complex.result, complex_result)
+        self.assertIsNone(valid_response_complex.error)
+
+        # Test valid response with list result
+        list_result = ["item1", "item2", "item3"]
+        valid_response_list = SkillApiResponseData(result=list_result)
+        self.assertEqual(valid_response_list.result, list_result)
+
+        # Test response with both result and error (should be allowed)
+        both_fields_response = SkillApiResponseData(
+            result="some result",
+            error="some error"
+        )
+        self.assertEqual(both_fields_response.result, "some result")
+        self.assertEqual(both_fields_response.error, "some error")
+
+        # Test default values (both None)
+        default_response = SkillApiResponseData()
+        self.assertIsNone(default_response.result)
+        self.assertIsNone(default_response.error)
+
+        # Test with various data types as result
+        int_result = SkillApiResponseData(result=42)
+        float_result = SkillApiResponseData(result=3.14159)
+        bool_result = SkillApiResponseData(result=True)
+        
+        self.assertEqual(int_result.result, 42)
+        self.assertEqual(float_result.result, 3.14159)
+        self.assertTrue(bool_result.result)
+    
+    def test_neon_call_skill_api(self):
+        from neon_data_models.models.api.messagebus import NeonCallSkillApi, SkillApiRequestData
+        from neon_data_models.models.base.messagebus import BaseMessage
+
+        # Test valid message with specific msg_type
+        request_data = SkillApiRequestData(
+            args=["test_location"],
+            kwargs={"format": "iso"}
+        )
+        valid_message = NeonCallSkillApi(
+            msg_type="skill-date_time.neongeckocom.get_current_time",
+            data=request_data,
+            context={}
+        )
+        self.assertIsInstance(valid_message, NeonCallSkillApi)
+        self.assertIsInstance(valid_message, BaseMessage)
+        self.assertEqual(valid_message.msg_type, "skill-date_time.neongeckocom.get_current_time")
+        self.assertEqual(valid_message.data.args, ["test_location"])
+        self.assertEqual(valid_message.data.kwargs, {"format": "iso"})
+
+        # Test with default data
+        message_with_default = NeonCallSkillApi(
+            msg_type="test.skill.method",
+            context={}
+        )
+        self.assertEqual(message_with_default.data.args, [])
+        self.assertEqual(message_with_default.data.kwargs, {})
+
+        # Test with empty request data
+        empty_request = SkillApiRequestData()
+        message_empty = NeonCallSkillApi(
+            msg_type="test.skill.empty",
+            data=empty_request,
+            context={}
+        )
+        self.assertEqual(message_empty.data.args, [])
+        self.assertEqual(message_empty.data.kwargs, {})
+
+        # Test with complex arguments
+        complex_args = [
+            {"nested": "object"},
+            [1, 2, 3],
+            "simple_string",
+            42,
+            True
+        ]
+        complex_kwargs = {
+            "config": {"setting": "value"},
+            "options": ["opt1", "opt2"],
+            "enabled": True
+        }
+        complex_request = SkillApiRequestData(args=complex_args, kwargs=complex_kwargs)
+        complex_message = NeonCallSkillApi(
+            msg_type="skill.complex.method",
+            data=complex_request,
+            context={"source": "test"}
+        )
+        self.assertEqual(complex_message.data.args[0]["nested"], "object")
+        self.assertEqual(complex_message.data.kwargs["config"]["setting"], "value")
+
+        # Test missing required msg_type
+        with self.assertRaises(ValidationError):
+            NeonCallSkillApi(data=request_data, context={})
+    
+    def test_neon_call_skill_api_response(self):
+        from neon_data_models.models.api.messagebus import NeonCallSkillApiResponse, SkillApiResponseData
+        from neon_data_models.models.base.messagebus import BaseMessage
+
+        # Test valid response with successful result
+        response_data = SkillApiResponseData(
+            result={
+                "current_timestamp": 1640995200.0,
+                "formatted_time": "2022-01-01 00:00:00 UTC"
+            },
+            error=None
+        )
+        valid_response = NeonCallSkillApiResponse(
+            msg_type="skill-date_time.neongeckocom.get_current_time.response",
+            data=response_data,
+            context={}
+        )
+        self.assertIsInstance(valid_response, NeonCallSkillApiResponse)
+        self.assertIsInstance(valid_response, BaseMessage)
+        self.assertEqual(valid_response.msg_type, "skill-date_time.neongeckocom.get_current_time.response")
+        self.assertEqual(valid_response.data.result["current_timestamp"], 1640995200.0)
+        self.assertIsNone(valid_response.data.error)
+
+        # Test response with error
+        error_response_data = SkillApiResponseData(
+            result=None,
+            error="Failed to get current time: Network error"
+        )
+        error_response = NeonCallSkillApiResponse(
+            msg_type="skill-date_time.neongeckocom.get_current_time.response",
+            data=error_response_data,
+            context={}
+        )
+        self.assertIsNone(error_response.data.result)
+        self.assertEqual(error_response.data.error, "Failed to get current time: Network error")
+
+        # Test with simple result types
+        string_response = NeonCallSkillApiResponse(
+            msg_type="test.skill.string.response",
+            data=SkillApiResponseData(result="Simple string result"),
+            context={}
+        )
+        self.assertEqual(string_response.data.result, "Simple string result")
+
+        number_response = NeonCallSkillApiResponse(
+            msg_type="test.skill.number.response",
+            data=SkillApiResponseData(result=42),
+            context={}
+        )
+        self.assertEqual(number_response.data.result, 42)
+
+        list_response = NeonCallSkillApiResponse(
+            msg_type="test.skill.list.response",
+            data=SkillApiResponseData(result=["item1", "item2", "item3"]),
+            context={}
+        )
+        self.assertEqual(len(list_response.data.result), 3)
+        self.assertEqual(list_response.data.result[1], "item2")
+
+        # Test with both result and error (edge case)
+        mixed_response = NeonCallSkillApiResponse(
+            msg_type="test.skill.mixed.response",
+            data=SkillApiResponseData(
+                result="Partial result",
+                error="Warning: incomplete data"
+            ),
+            context={}
+        )
+        self.assertEqual(mixed_response.data.result, "Partial result")
+        self.assertEqual(mixed_response.data.error, "Warning: incomplete data")
+
+        # Test missing required msg_type
+        with self.assertRaises(ValidationError):
+            NeonCallSkillApiResponse(data=response_data, context={})
+
+        # Test missing required data
+        with self.assertRaises(ValidationError):
+            NeonCallSkillApiResponse(
+                msg_type="test.response",
+                context={}
+            )
+    

--- a/tests/models/api/test_mq.py
+++ b/tests/models/api/test_mq.py
@@ -445,10 +445,28 @@ class TestNeonMQ(TestCase):
         # with self.assertRaises(ValidationError):
         #     NeonMqTtsResponse(message_id="test_mid")
 
+    def test_neon_mq_get_skills_api(self):
+        from neon_data_models.models.api.mq.neon import NeonMqGetSkillsApi
+        # TODO
+    
+    def test_neon_mq_skills_api_response(self):
+        from neon_data_models.models.api.mq.neon import NeonMqSkillsApiResponse
+        # TODO
+    
+    def test_neon_mq_call_skill_api(self):
+        from neon_data_models.models.api.mq.neon import NeonMqCallSkillApi
+        # TODO
+    
+    def test_neon_mq_call_skill_api_response(self):
+        from neon_data_models.models.api.mq.neon import NeonMqCallSkillApiResponse
+        # TODO
+
     def test_neon_api_message(self):
         from neon_data_models.models.api.mq.neon import NeonApiMessage, GetTtsData, GetSttData, GetResponseData
         from neon_data_models.models.api.mq.neon import NeonMqGetTts, NeonMqGetStt, NeonMqTextInput
         from neon_data_models.models.api.mq.neon import NeonMqSttResponse, NeonMqTtsResponse
+        from neon_data_models.models.api.mq.neon import NeonMqGetSkillsApi, NeonMqSkillsApiResponse
+        from neon_data_models.models.api.mq.neon import NeonMqCallSkillApi, NeonMqCallSkillApiResponse
 
         # Test TTS message
         tts_message = NeonApiMessage(
@@ -500,6 +518,62 @@ class TestNeonMQ(TestCase):
             message_id="test_mid"
         )
         self.assertIsInstance(tts_response, NeonMqTtsResponse)
+
+        # Test Get Skills API message
+        skills_api_message = NeonApiMessage(
+            msg_type="neon.skill_api.get",
+            data={},
+            context={},
+            message_id="test_mid"
+        )
+        self.assertIsInstance(skills_api_message, NeonMqGetSkillsApi)
+
+        # Test Skills API Response message
+        skills_api_response = NeonApiMessage(
+            msg_type="neon.skill_api.get.response",
+            data={
+                "skill-date_time.neongeckocom": {
+                    "get_current_time": {
+                        "help": "Get the current timestamp",
+                        "type": "skill-date_time.neongeckocom.get_current_time",
+                        "request_schema": None,
+                        "response_schema": None,
+                        "signature": None
+                    }
+                }
+            },
+            context={},
+            message_id="test_mid"
+        )
+        self.assertIsInstance(skills_api_response, NeonMqSkillsApiResponse)
+
+        # Test Call Skill API message
+        call_skill_api_message = NeonApiMessage(
+            msg_type="neon.skill_api.call",
+            data={
+                "msg_type": "skill-date_time.neongeckocom.get_current_time",
+                "args": ["Seattle"],
+                "kwargs": {"format": "iso"}
+            },
+            context={},
+            message_id="test_mid"
+        )
+        self.assertIsInstance(call_skill_api_message, NeonMqCallSkillApi)
+
+        # Test Call Skill API Response message
+        call_skill_api_response = NeonApiMessage(
+            msg_type="neon.skill_api.response",
+            data={
+                "result": {
+                    "current_timestamp": 1640995200.0,
+                    "formatted_time": "2022-01-01 00:00:00 UTC"
+                },
+                "error": None
+            },
+            context={},
+            message_id="test_mid"
+        )
+        self.assertIsInstance(call_skill_api_response, NeonMqCallSkillApiResponse)
 
         # Test from_sio_message for STT
         sio_stt = {


### PR DESCRIPTION
# Description
Adds HTTP, MQ, and Messagebus models relating to the Skill API

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
- Relates to https://github.com/NeonGeckoCom/neon-phal-plugin-skill-api/pull/1
- Needed by https://github.com/NeonGeckoCom/neon-messagebus-mq-connector/pull/65
- Consider if `NeonHttpListSkillApiResponse` should return a dict by `skill_id`, or a flat list of methods