### PR TITLE
Add models for Node native actions (node.hello, node.invoke_native)

### DIFF
--- a/neon_data_models/enum.py
+++ b/neon_data_models/enum.py
@@ -123,3 +123,29 @@ class CcaiControl(Enum):
     CREATE_PROMPT = "!MSG:CREATE_PROMPT"
     START_AUTO_PROMPTS = "!START_AUTO_PROMPTS"
     STOP_AUTO_PROMPTS = "!STOP_AUTO_PROMPTS"
+
+
+class NodeNativeAction(Enum):
+    """
+    Defines platform-native actions a Node client may perform in response to
+    a `node.invoke_native` request. Each value is also the capability key a
+    Node advertises in `node.hello`.
+    """
+    LAUNCH_CAMERA_APP = "launch_camera_app"
+    LAUNCH_VOICE_RECORDER_APP = "launch_voice_recorder_app"
+    LAUNCH_REMINDERS_APP = "launch_reminders_app"
+    LAUNCH_CLOCK_APP = "launch_clock_app"
+    LAUNCH_SMS_APP = "launch_sms_app"
+    LAUNCH_EMAIL_APP = "launch_email_app"
+
+
+class NativeActionErrorCode(Enum):
+    """
+    Defines error codes a Node may return in a `node.invoke_native.response`.
+    String values are used so failures are debuggable in logs without a
+    translation table; numeric codes may be layered on later additively.
+    """
+    NOT_SUPPORTED = "not_supported"
+    PERMISSION_DENIED = "permission_denied"
+    UNAVAILABLE = "unavailable"
+    INTERNAL_ERROR = "internal_error"

--- a/neon_data_models/models/api/node_v1/__init__.py
+++ b/neon_data_models/models/api/node_v1/__init__.py
@@ -25,10 +25,11 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from datetime import datetime, timedelta
-from pydantic import Field
+from pydantic import Field, model_validator
 from typing import List, Literal, Optional, Annotated, Dict
 
-from neon_data_models.enum import UserData, AlertType, Weekdays
+from neon_data_models.enum import (UserData, AlertType, Weekdays,
+                                   NodeNativeAction, NativeActionErrorCode)
 from neon_data_models.models.base import BaseModel
 from neon_data_models.models.base.messagebus import BaseMessage, MessageContext
 
@@ -134,6 +135,66 @@ class CoreClearData(BaseMessage):
     data: ClearDataData
 
 
+class NodeHello(BaseMessage):
+    class NodeHelloData(BaseModel):
+        node_id: str = Field(description="Session-scoped Node client ID")
+        # node_name is stamped onto every outbound bus message via
+        # `context.node`, so an unbounded value would be amplified per-message
+        node_name: str = Field(
+            default="", max_length=128,
+            description="User-editable Node device name")
+        capabilities: Dict[str, bool] = Field(
+            default={},
+            description="Mapping of native action name (see NodeNativeAction) "
+                        "to supported state. `false` or absent means the "
+                        "action is not supported on this Node.")
+
+    msg_type: Literal["node.hello"] = "node.hello"
+    data: NodeHelloData
+
+
+class NodeInvokeNative(BaseMessage):
+    class InvokeNativeData(BaseModel):
+        action: NodeNativeAction = Field(
+            description="Native action for the Node to perform")
+        params: dict = Field(
+            default={},
+            description="Parameters for the requested action. Most actions "
+                        "take none. To pre-fill the message composer, "
+                        "`launch_sms_app` accepts `to` and `body`; "
+                        "`launch_email_app` accepts `to`, `subject`, and "
+                        "`body`. Nodes ignore unrecognized keys.")
+
+    msg_type: Literal["node.invoke_native"] = "node.invoke_native"
+    data: InvokeNativeData
+
+
+class NodeInvokeNativeResponse(BaseMessage):
+    class InvokeNativeResponseData(BaseModel):
+        class NativeActionError(BaseModel):
+            code: NativeActionErrorCode
+            message: str = Field(
+                default="", description="Human-readable error description")
+
+        action: NodeNativeAction = Field(
+            description="Native action this response corresponds to")
+        status: Literal["success", "error"]
+        error: Optional[NativeActionError] = Field(
+            default=None, description="Required when `status` is `error`")
+
+        @model_validator(mode="after")
+        def validate_error_state(self):
+            if self.status == "error" and self.error is None:
+                raise ValueError("`error` is required when status is 'error'")
+            if self.status == "success" and self.error is not None:
+                raise ValueError("`error` is invalid when status is 'success'")
+            return self
+
+    msg_type: Literal["node.invoke_native.response"] = \
+        "node.invoke_native.response"
+    data: InvokeNativeResponseData
+
+
 class CoreAlertExpired(BaseMessage):
     class AlertData(BaseModel):
         alert_type: AlertType
@@ -154,6 +215,8 @@ class CoreAlertExpired(BaseMessage):
 __all__ = [NodeAudioInput.__name__, NodeTextInput.__name__, NodeGetStt.__name__,
            NodeGetTts.__name__, NodeKlatResponse.__name__,
            NodeAudioInputResponse.__name__, NodeGetSttResponse.__name__,
-           NodeGetTtsResponse.__name__, CoreWWDetected.__name__,
-           CoreIntentFailure.__name__, CoreErrorResponse.__name__,
-           CoreClearData.__name__, CoreAlertExpired.__name__]
+           NodeGetTtsResponse.__name__, NodeHello.__name__,
+           NodeInvokeNative.__name__, NodeInvokeNativeResponse.__name__,
+           CoreWWDetected.__name__, CoreIntentFailure.__name__,
+           CoreErrorResponse.__name__, CoreClearData.__name__,
+           CoreAlertExpired.__name__]

--- a/neon_data_models/models/api/node_v1/__init__.py
+++ b/neon_data_models/models/api/node_v1/__init__.py
@@ -26,11 +26,12 @@
 
 from datetime import datetime, timedelta
 from pydantic import Field, model_validator
-from typing import List, Literal, Optional, Annotated, Dict
+from typing import Any, List, Literal, Optional, Annotated, Dict
 
 from neon_data_models.enum import (UserData, AlertType, Weekdays,
                                    NodeNativeAction, NativeActionErrorCode)
 from neon_data_models.models.base import BaseModel
+from neon_data_models.models.base.contexts import NodeCapabilities
 from neon_data_models.models.base.messagebus import BaseMessage, MessageContext
 
 
@@ -143,11 +144,11 @@ class NodeHello(BaseMessage):
         node_name: str = Field(
             default="", max_length=128,
             description="User-editable Node device name")
-        capabilities: Dict[str, bool] = Field(
+        capabilities: NodeCapabilities = Field(
             default={},
-            description="Mapping of native action name (see NodeNativeAction) "
-                        "to supported state. `false` or absent means the "
-                        "action is not supported on this Node.")
+            description="Mapping of native action to supported state. "
+                        "`false` or absent means the action is not supported "
+                        "on this Node.")
 
     msg_type: Literal["node.hello"] = "node.hello"
     data: NodeHelloData
@@ -157,7 +158,7 @@ class NodeInvokeNative(BaseMessage):
     class InvokeNativeData(BaseModel):
         action: NodeNativeAction = Field(
             description="Native action for the Node to perform")
-        params: dict = Field(
+        params: Dict[str, Any] = Field(
             default={},
             description="Parameters for the requested action. Most actions "
                         "take none. To pre-fill the message composer, "

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -25,7 +25,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from datetime import datetime, timedelta, timezone
-from typing import Literal, List, Optional, Any, Tuple
+from typing import Dict, Literal, List, Optional, Any, Tuple
 from uuid import uuid4
 
 from pydantic import Field, model_validator
@@ -155,3 +155,21 @@ class MQContext(BaseModel):
 
 class GradioContext(BaseModel):
     session: str = Field(description="Gradio session ID")
+
+
+class NodeContext(BaseModel):
+    """
+    Identity and capability snapshot for the Node session a message originated
+    from. HANA populates this on every outbound bus message from a Node
+    session, cached from the session's `node.hello`, so skills can read
+    capabilities synchronously without an extra round-trip.
+    """
+    node_id: str = Field(description="Session-scoped Node client ID")
+    node_name: str = Field(
+        default="", max_length=128,
+        description="User-editable Node device name")
+    site_id: Optional[str] = Field(
+        default=None, description="User-defined room/site label")
+    capabilities: Dict[str, bool] = Field(
+        default={}, description="Mapping of native action name to supported "
+                                "state. Absent keys mean unsupported.")

--- a/neon_data_models/models/base/contexts.py
+++ b/neon_data_models/models/base/contexts.py
@@ -25,11 +25,12 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from datetime import datetime, timedelta, timezone
-from typing import Dict, Literal, List, Optional, Any, Tuple
+from typing import Annotated, Dict, Literal, List, Optional, Any, Tuple
 from uuid import uuid4
 
-from pydantic import Field, model_validator
+from pydantic import BeforeValidator, Field, PlainSerializer, model_validator
 
+from neon_data_models.enum import NodeNativeAction
 from neon_data_models.models.base import BaseModel
 
 
@@ -157,6 +158,26 @@ class GradioContext(BaseModel):
     session: str = Field(description="Gradio session ID")
 
 
+def _drop_unknown_capabilities(value):
+    if isinstance(value, dict):
+        known_actions = {action.value for action in NodeNativeAction}
+        return {key: supported for key, supported in value.items()
+                if isinstance(key, NodeNativeAction) or key in known_actions}
+    return value
+
+
+# Keys are constrained to `NodeNativeAction` so equivalent actions don't get
+# re-defined under new names. Unrecognized keys are dropped rather than
+# rejected: a Node newer than this schema may advertise actions this version
+# cannot invoke anyway, and that must not invalidate the whole message.
+NodeCapabilities = Annotated[
+    Dict[NodeNativeAction, bool],
+    BeforeValidator(_drop_unknown_capabilities),
+    PlainSerializer(lambda caps: {action.value: supported
+                                  for action, supported in caps.items()},
+                    return_type=Dict[str, bool])]
+
+
 class NodeContext(BaseModel):
     """
     Identity and capability snapshot for the Node session a message originated
@@ -170,6 +191,6 @@ class NodeContext(BaseModel):
         description="User-editable Node device name")
     site_id: Optional[str] = Field(
         default=None, description="User-defined room/site label")
-    capabilities: Dict[str, bool] = Field(
-        default={}, description="Mapping of native action name to supported "
+    capabilities: NodeCapabilities = Field(
+        default={}, description="Mapping of native action to supported "
                                 "state. Absent keys mean unsupported.")

--- a/neon_data_models/models/base/messagebus.py
+++ b/neon_data_models/models/base/messagebus.py
@@ -28,9 +28,10 @@ from typing import Optional, List, Union
 from pydantic import ConfigDict, Field, field_validator, model_validator
 
 from neon_data_models.models.base import BaseModel
-from neon_data_models.models.base.contexts import (GradioContext, 
+from neon_data_models.models.base.contexts import (GradioContext,
                                                    SessionContext, KlatContext,
-                                                   TimingContext, MQContext)
+                                                   TimingContext, MQContext,
+                                                   NodeContext)
 from neon_data_models.models.client.node import NodeData
 from neon_data_models.models.user.neon_profile import UserProfile
 
@@ -40,6 +41,10 @@ class MessageContext(BaseModel):
     session: SessionContext = Field(description="Session Data",
                                               default=SessionContext())
     node_data: Optional[NodeData] = Field(description="Node Data", default=None)
+    node: Optional[NodeContext] = Field(
+        description="Identity and capabilities of the originating Node "
+                    "session, populated hub-side from `node.hello`",
+        default=None)
     timing: TimingContext = Field(
         description="User Interaction Timing Information", 
         default=TimingContext())

--- a/tests/models/api/test_node.py
+++ b/tests/models/api/test_node.py
@@ -325,3 +325,205 @@ class TestNodeV1(TestCase):
         # Validate cast from timestamp/epoch to datetime/timedelta
         self.assertEqual(CoreAlertExpired(data=datetime_alert, context={}),
                          CoreAlertExpired(data=iso_alert, context={}))
+
+    def test_node_hello(self):
+        from neon_data_models.models.api.node_v1 import NodeHello
+        valid_data = {"node_id": "node-a1b2c3d4",
+                      "node_name": "Kitchen Phone",
+                      "capabilities": {"launch_camera_app": True,
+                                       "launch_sms_app": False}}
+
+        # Invalid msg_type
+        with self.assertRaises(ValidationError):
+            NodeHello(msg_type="bad_message_type",
+                      data=valid_data, context={})
+
+        # Missing context
+        with self.assertRaises(ValidationError):
+            NodeHello(data=valid_data)
+
+        # Missing node_id
+        with self.assertRaises(ValidationError):
+            NodeHello(data={"node_name": "Kitchen Phone"}, context={})
+
+        # Valid with or without `msg_type` explicitly passed
+        self.assertEqual(NodeHello(msg_type="node.hello",
+                                   data=valid_data, context={}),
+                         NodeHello(data=valid_data, context={}))
+
+        # name and capabilities are optional
+        minimal = NodeHello(data={"node_id": "node-a1b2c3d4"}, context={})
+        self.assertEqual(minimal.data.node_name, "")
+        self.assertEqual(minimal.data.capabilities, {})
+
+        # Unknown capability keys are allowed (forward-compatibility)
+        extended = NodeHello(data={**valid_data,
+                                   "capabilities": {"future_action": True}},
+                             context={})
+        self.assertTrue(extended.data.capabilities["future_action"])
+
+    def test_node_invoke_native(self):
+        from neon_data_models.models.api.node_v1 import NodeInvokeNative
+        from neon_data_models.enum import NodeNativeAction
+
+        # Launch-only action
+        launch_only = NodeInvokeNative(data={"action": "launch_camera_app"},
+                                       context={})
+        self.assertEqual(launch_only.data.action,
+                         NodeNativeAction.LAUNCH_CAMERA_APP)
+        self.assertEqual(launch_only.data.params, {})
+
+        # Action with pre-fill payload
+        with_params = NodeInvokeNative(
+            data={"action": "launch_email_app",
+                  "params": {"subject": "Running late", "body": "Sorry!"}},
+            context={})
+        self.assertEqual(with_params.data.params["subject"], "Running late")
+
+        # Unknown action is rejected
+        with self.assertRaises(ValidationError):
+            NodeInvokeNative(data={"action": "launch_unknown_app"},
+                             context={})
+
+        # Missing action is rejected
+        with self.assertRaises(ValidationError):
+            NodeInvokeNative(data={}, context={})
+
+        # Action enum serializes to its wire string
+        self.assertEqual(launch_only.model_dump()["data"]["action"],
+                         "launch_camera_app")
+
+    def test_node_invoke_native_response(self):
+        from neon_data_models.models.api.node_v1 import NodeInvokeNativeResponse
+        from neon_data_models.enum import NativeActionErrorCode
+
+        # Success response
+        success = NodeInvokeNativeResponse(
+            data={"action": "launch_camera_app", "status": "success"},
+            context={})
+        self.assertIsNone(success.data.error)
+
+        # Error response
+        error = NodeInvokeNativeResponse(
+            data={"action": "launch_camera_app", "status": "error",
+                  "error": {"code": "unavailable",
+                            "message": "No camera app is available."}},
+            context={})
+        self.assertEqual(error.data.error.code,
+                         NativeActionErrorCode.UNAVAILABLE)
+
+        # Error status without an error object is rejected
+        with self.assertRaises(ValidationError):
+            NodeInvokeNativeResponse(
+                data={"action": "launch_camera_app", "status": "error"},
+                context={})
+
+        # Success status with an error object is rejected
+        with self.assertRaises(ValidationError):
+            NodeInvokeNativeResponse(
+                data={"action": "launch_camera_app", "status": "success",
+                      "error": {"code": "unavailable"}},
+                context={})
+
+        # Unknown error code is rejected
+        with self.assertRaises(ValidationError):
+            NodeInvokeNativeResponse(
+                data={"action": "launch_camera_app", "status": "error",
+                      "error": {"code": "not_an_error_code"}},
+                context={})
+
+        # Error code serializes to its wire string
+        self.assertEqual(
+            error.model_dump()["data"]["error"]["code"], "unavailable")
+
+    def test_native_action_wire_strings(self):
+        # These enum values are the wire contract shared with HANA, the
+        # skills, and the Node app. Changing one is a breaking change.
+        from neon_data_models.enum import (NodeNativeAction,
+                                           NativeActionErrorCode)
+        self.assertEqual({a.value for a in NodeNativeAction},
+                         {"launch_camera_app", "launch_voice_recorder_app",
+                          "launch_reminders_app", "launch_clock_app",
+                          "launch_sms_app", "launch_email_app"})
+        self.assertEqual({c.value for c in NativeActionErrorCode},
+                         {"not_supported", "permission_denied",
+                          "unavailable", "internal_error"})
+
+    def test_native_action_models_round_trip(self):
+        from neon_data_models.models.api.node_v1 import (
+            NodeHello, NodeInvokeNative, NodeInvokeNativeResponse)
+        from neon_data_models.enum import NodeNativeAction
+
+        hello = NodeHello(
+            data={"node_id": "node-a1b2c3d4", "node_name": "Kitchen Phone",
+                  "capabilities": {a.value: True for a in NodeNativeAction}},
+            context={})
+        invoke = NodeInvokeNative(
+            data={"action": "launch_sms_app",
+                  "params": {"to": "+15551234567", "body": "On my way"}},
+            context={})
+        response = NodeInvokeNativeResponse(
+            data={"action": "launch_sms_app", "status": "error",
+                  "error": {"code": "not_supported"}},
+            context={})
+
+        # Serialization round-trips to an equal object for every model
+        self.assertEqual(hello, NodeHello(**hello.model_dump()))
+        self.assertEqual(invoke, NodeInvokeNative(**invoke.model_dump()))
+        self.assertEqual(response,
+                         NodeInvokeNativeResponse(**response.model_dump()))
+
+    def test_native_action_models_as_messagebus_message(self):
+        # HANA consumes these via `as_messagebus_message`; enum fields must
+        # arrive on the bus as their wire strings, not Enum objects
+        from neon_data_models.models.api.node_v1 import (
+            NodeInvokeNative, NodeInvokeNativeResponse)
+
+        invoke = NodeInvokeNative(data={"action": "launch_clock_app"},
+                                  context={})
+        bus_msg = invoke.as_messagebus_message()
+        self.assertEqual(bus_msg.msg_type, "node.invoke_native")
+        self.assertEqual(bus_msg.data["action"], "launch_clock_app")
+
+        response = NodeInvokeNativeResponse(
+            data={"action": "launch_clock_app", "status": "error",
+                  "error": {"code": "internal_error", "message": "oops"}},
+            context={})
+        bus_msg = response.as_messagebus_message()
+        self.assertEqual(bus_msg.msg_type, "node.invoke_native.response")
+        self.assertEqual(bus_msg.data["error"]["code"], "internal_error")
+
+    def test_native_action_version_skew_tolerance(self):
+        # An older hub must tolerate payloads from a newer Node: unknown
+        # fields are dropped, unknown capability keys and params are carried.
+        # (Unknown `action`/`error.code` values are strictly rejected by
+        # design — extending those enums is a coordinated release.)
+        from neon_data_models.models.api.node_v1 import (NodeHello,
+                                                         NodeInvokeNative)
+
+        # Unknown fields added by a future spec revision are ignored
+        hello = NodeHello(data={"node_id": "node-a1b2c3d4",
+                                "protocol_version": 2},
+                          context={})
+        self.assertIsNone(hello.data.model_dump().get("protocol_version"))
+
+        # Unknown params keys are retained so a relaying hub passes them
+        # through to the Node untouched
+        invoke = NodeInvokeNative(
+            data={"action": "launch_email_app",
+                  "params": {"subject": "hi", "importance": "high"}},
+            context={})
+        self.assertEqual(invoke.data.params["importance"], "high")
+        self.assertEqual(
+            invoke.model_dump()["data"]["params"]["importance"], "high")
+
+    def test_node_hello_name_length_cap(self):
+        from neon_data_models.models.api.node_v1 import NodeHello
+        from neon_data_models.models.base.contexts import NodeContext
+
+        NodeHello(data={"node_id": "n", "node_name": "x" * 128}, context={})
+        with self.assertRaises(ValidationError):
+            NodeHello(data={"node_id": "n", "node_name": "x" * 129},
+                      context={})
+        with self.assertRaises(ValidationError):
+            NodeContext(node_id="n", node_name="x" * 129)

--- a/tests/models/api/test_node.py
+++ b/tests/models/api/test_node.py
@@ -328,6 +328,7 @@ class TestNodeV1(TestCase):
 
     def test_node_hello(self):
         from neon_data_models.models.api.node_v1 import NodeHello
+        from neon_data_models.enum import NodeNativeAction
         valid_data = {"node_id": "node-a1b2c3d4",
                       "node_name": "Kitchen Phone",
                       "capabilities": {"launch_camera_app": True,
@@ -347,20 +348,33 @@ class TestNodeV1(TestCase):
             NodeHello(data={"node_name": "Kitchen Phone"}, context={})
 
         # Valid with or without `msg_type` explicitly passed
+        hello = NodeHello(data=valid_data, context={})
         self.assertEqual(NodeHello(msg_type="node.hello",
-                                   data=valid_data, context={}),
-                         NodeHello(data=valid_data, context={}))
+                                   data=valid_data, context={}), hello)
+
+        # Capability keys validate to `NodeNativeAction` and serialize back
+        # to wire strings
+        self.assertTrue(
+            hello.data.capabilities[NodeNativeAction.LAUNCH_CAMERA_APP])
+        self.assertFalse(
+            hello.data.capabilities[NodeNativeAction.LAUNCH_SMS_APP])
+        self.assertEqual(hello.model_dump()["data"]["capabilities"],
+                         {"launch_camera_app": True,
+                          "launch_sms_app": False})
 
         # name and capabilities are optional
         minimal = NodeHello(data={"node_id": "node-a1b2c3d4"}, context={})
         self.assertEqual(minimal.data.node_name, "")
         self.assertEqual(minimal.data.capabilities, {})
 
-        # Unknown capability keys are allowed (forward-compatibility)
+        # Unknown capability keys are dropped, not rejected
+        # (forward-compatibility with Nodes newer than this schema)
         extended = NodeHello(data={**valid_data,
-                                   "capabilities": {"future_action": True}},
+                                   "capabilities": {"future_action": True,
+                                                    "launch_sms_app": True}},
                              context={})
-        self.assertTrue(extended.data.capabilities["future_action"])
+        self.assertEqual(extended.data.capabilities,
+                         {NodeNativeAction.LAUNCH_SMS_APP: True})
 
     def test_node_invoke_native(self):
         from neon_data_models.models.api.node_v1 import NodeInvokeNative
@@ -495,7 +509,7 @@ class TestNodeV1(TestCase):
 
     def test_native_action_version_skew_tolerance(self):
         # An older hub must tolerate payloads from a newer Node: unknown
-        # fields are dropped, unknown capability keys and params are carried.
+        # fields and capability keys are dropped, unknown params are carried.
         # (Unknown `action`/`error.code` values are strictly rejected by
         # design — extending those enums is a coordinated release.)
         from neon_data_models.models.api.node_v1 import (NodeHello,

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -492,6 +492,7 @@ class TestMessagebus(TestCase):
         self.assertIsInstance(nested_none_context.session, SessionContext)
 
     def test_node_context(self):
+        from neon_data_models.enum import NodeNativeAction
         from neon_data_models.models.base.contexts import NodeContext
         from neon_data_models.models.base.messagebus import MessageContext
 
@@ -514,4 +515,7 @@ class TestMessagebus(TestCase):
         self.assertIsNone(MessageContext().node)
         ctx = MessageContext(node=populated.model_dump())
         self.assertIsInstance(ctx.node, NodeContext)
-        self.assertEqual(ctx.node.capabilities["launch_camera_app"], True)
+        self.assertTrue(
+            ctx.node.capabilities[NodeNativeAction.LAUNCH_CAMERA_APP])
+        self.assertEqual(ctx.model_dump()["node"]["capabilities"],
+                         {"launch_camera_app": True})

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -490,3 +490,28 @@ class TestMessagebus(TestCase):
         nested_none_context = MessageContext(**{"session": None})
         self.assertIsNotNone(nested_none_context.session)
         self.assertIsInstance(nested_none_context.session, SessionContext)
+
+    def test_node_context(self):
+        from neon_data_models.models.base.contexts import NodeContext
+        from neon_data_models.models.base.messagebus import MessageContext
+
+        # node_id is required
+        with self.assertRaises(ValidationError):
+            NodeContext()
+
+        minimal = NodeContext(node_id="node-a1b2c3d4")
+        self.assertEqual(minimal.node_name, "")
+        self.assertIsNone(minimal.site_id)
+        self.assertEqual(minimal.capabilities, {})
+
+        populated = NodeContext(node_id="node-a1b2c3d4",
+                                node_name="Kitchen Phone",
+                                site_id="kitchen",
+                                capabilities={"launch_camera_app": True})
+        self.assertEqual(populated, NodeContext(**populated.model_dump()))
+
+        # MessageContext carries an optional `node` context
+        self.assertIsNone(MessageContext().node)
+        ctx = MessageContext(node=populated.model_dump())
+        self.assertIsInstance(ctx.node, NodeContext)
+        self.assertEqual(ctx.node.capabilities["launch_camera_app"], True)


### PR DESCRIPTION
Adds the wire models for the Platform-Native Actions spec (PLATFORM_NATIVE_ACTIONS.md v0.3, approved in neon-node-design#3).

## Changes

- `NodeHello` — capability advertisement at WS connect. Carries `node_id`, user-editable `node_name` (US-N01), and a flat `capabilities` map.
- `NodeInvokeNative` — Hub→Node action dispatch. `params` is an open dict; only `launch_sms_app`/`launch_email_app` read it in v1 (composer pre-fill).
- `NodeInvokeNativeResponse` — Node→Hub ack. Validator enforces `status: error` carries an `error` object and `status: success` does not.
- `NodeNativeAction` / `NativeActionErrorCode` enums — the authoritative wire strings for both sides.
- `NodeContext` + optional `MessageContext.node` — the per-session identity/capability snapshot HANA stamps on outbound bus messages (Hub-side half of US-N01).

## Design notes

- `capabilities` is `Dict[str, bool]`, not enum-keyed: a newer Node advertising an unknown capability must not fail validation on an older hub ("absent means unsupported"). `action` stays a strict enum so a hub never dispatches an action it doesn't recognize.
- `node_name` is capped at 128 chars — it rides on every outbound bus message via `context.node`, so an unbounded value would be amplified per-message.
- All changes are additive. `MessageContext.node` defaults to `None`; existing messages are unaffected.

## Testing

New tests cover validation (unknown action/error code rejected, error-state coherence), serialization round-trips, `as_messagebus_message` output (enums arrive as wire strings), version-skew tolerance (unknown fields/params from newer Nodes), and the wire-string golden list.
