### PR TITLE
feat: add NodeHelloResponse model

### DIFF
--- a/neon_data_models/models/api/node_v1/__init__.py
+++ b/neon_data_models/models/api/node_v1/__init__.py
@@ -196,6 +196,50 @@ class NodeInvokeNativeResponse(BaseMessage):
     data: InvokeNativeResponseData
 
 
+class NodeHelloResponse(BaseMessage):
+    """
+    Hub acknowledgement of a `node.hello`: the normalized snapshot as
+    cached (what `context.node` will carry), or the validation error that
+    made the hub drop it. Hubs that predate this never send one.
+    """
+    class HelloResponseData(BaseModel):
+        class NormalizedNode(BaseModel):
+            node_id: str = Field(
+                description="Session-derived Node ID as cached by the hub")
+            node_name: str = Field(
+                default="", max_length=128,
+                description="Node device name as cached by the hub")
+            capabilities: NodeCapabilities = Field(
+                default={},
+                description="Capabilities as cached by the hub")
+
+        class HelloError(BaseModel):
+            message: str = Field(
+                default="",
+                description="Why the hub dropped the `node.hello`")
+
+        status: Literal["success", "error"]
+        node: Optional[NormalizedNode] = Field(
+            default=None, description="Required when `status` is `success`")
+        error: Optional[HelloError] = Field(
+            default=None, description="Required when `status` is `error`")
+
+        @model_validator(mode="after")
+        def validate_status_state(self):
+            if self.status == "success" and self.node is None:
+                raise ValueError("`node` is required when status is "
+                                 "'success'")
+            if self.status == "success" and self.error is not None:
+                raise ValueError("`error` is invalid when status is "
+                                 "'success'")
+            if self.status == "error" and self.error is None:
+                raise ValueError("`error` is required when status is 'error'")
+            return self
+
+    msg_type: Literal["node.hello.response"] = "node.hello.response"
+    data: HelloResponseData
+
+
 class CoreAlertExpired(BaseMessage):
     class AlertData(BaseModel):
         alert_type: AlertType
@@ -218,6 +262,7 @@ __all__ = [NodeAudioInput.__name__, NodeTextInput.__name__, NodeGetStt.__name__,
            NodeAudioInputResponse.__name__, NodeGetSttResponse.__name__,
            NodeGetTtsResponse.__name__, NodeHello.__name__,
            NodeInvokeNative.__name__, NodeInvokeNativeResponse.__name__,
+           NodeHelloResponse.__name__,
            CoreWWDetected.__name__, CoreIntentFailure.__name__,
            CoreErrorResponse.__name__, CoreClearData.__name__,
            CoreAlertExpired.__name__]

--- a/tests/models/api/test_node.py
+++ b/tests/models/api/test_node.py
@@ -450,6 +450,49 @@ class TestNodeV1(TestCase):
         self.assertEqual(
             error.model_dump()["data"]["error"]["code"], "unavailable")
 
+    def test_node_hello_response(self):
+        from neon_data_models.models.api.node_v1 import NodeHelloResponse
+
+        # Success carries the hub-normalized snapshot
+        success = NodeHelloResponse(
+            data={"status": "success",
+                  "node": {"node_id": "session-123",
+                           "node_name": "Kitchen Phone",
+                           "capabilities": {"launch_camera_app": True}}},
+            context={})
+        self.assertEqual(success.data.node.node_id, "session-123")
+        self.assertIsNone(success.data.error)
+
+        # Capability keys serialize back to wire strings
+        self.assertEqual(
+            success.model_dump()["data"]["node"]["capabilities"]
+            ["launch_camera_app"], True)
+
+        # Rejection carries the validation error
+        error = NodeHelloResponse(
+            data={"status": "error",
+                  "error": {"message": "data.node_id Field required"}},
+            context={})
+        self.assertIsNone(error.data.node)
+        self.assertEqual(error.data.error.message,
+                         "data.node_id Field required")
+
+        # Success without a node snapshot is rejected
+        with self.assertRaises(ValidationError):
+            NodeHelloResponse(data={"status": "success"}, context={})
+
+        # Success with an error object is rejected
+        with self.assertRaises(ValidationError):
+            NodeHelloResponse(
+                data={"status": "success",
+                      "node": {"node_id": "x"},
+                      "error": {"message": "nope"}},
+                context={})
+
+        # Error status without an error object is rejected
+        with self.assertRaises(ValidationError):
+            NodeHelloResponse(data={"status": "error"}, context={})
+
     def test_native_action_wire_strings(self):
         # These enum values are the wire contract shared with HANA, the
         # skills, and the Node app. Changing one is a breaking change.


### PR DESCRIPTION
Adds the model for `node.hello.response`, the hub's acknowledgement of a `node.hello` — proposed in review on `NeonGeckoCom/neon-hana#58` and implemented there (hub) and in `OscillateLabsLLC/neon-node-flutter-app` (node).

## Shape

- success: `{"status": "success", "node": {node_id, node_name, capabilities}}` — the hub-normalized snapshot as cached, i.e. what `context.node` will carry (session-derived `node_id`, not the client-claimed one)
- rejection: `{"status": "error", "error": {"message": <validation error>}}`

`status`/`error` mirror `NodeInvokeNativeResponse`, including the `model_validator` coupling `status` to the presence of `node`/`error`. Hubs that predate the ack simply never send one, which is what lets a Node flag an outdated hub.

## Why

Without the ack, a rejected `node.hello` is invisible to the Node: the hub logs a WARNING and everything downstream behaves as though the Node advertised nothing. We hit exactly this on-device — a missing `node_id` meant every hello was silently dropped and capability gating did nothing, with no error on either side.

## Tests

`test_node_hello_response` in the existing style: success snapshot, wire-string capability round-trip, rejection message, and the three invalid status/field combinations. 157 pass locally.

## Follow-ups once released

- `neon-hana#58` can construct the ack via this model (currently a hand-built `Message` with the same shape)
- hana's `node_v1_doc` unions can gain the new type

🤖 Generated with [Claude Code](https://claude.com/claude-code)