### PR TITLE
Add expect_response to TtsReponseData for klat.response

### DIFF
--- a/neon_data_models/models/api/messagebus/__init__.py
+++ b/neon_data_models/models/api/messagebus/__init__.py
@@ -117,6 +117,11 @@ class TtsReponseData(BaseModel):
     speaker: Optional[TtsSpeaker] = Field(
         default=None, description="Optional speaker metadata"
     )
+    expect_response: bool = Field(
+        default=False,
+        description="True if a response is expected after this TTS is "
+        "played, signaling the client to re-open the mic/listen",
+    )
 
 
 class GetSttData(BaseModel):

--- a/tests/models/api/test_messagebus.py
+++ b/tests/models/api/test_messagebus.py
@@ -331,11 +331,19 @@ class TestMessagebusModels(TestCase):
         self.assertEqual(valid_message.data.responses["en-us"].genders, ["female", "male"])
         self.assertEqual(valid_message.data.responses["en-us"].audio["female"], "base64audio1")
         self.assertEqual(valid_message.msg_type, "neon.get_tts.response")
+        self.assertFalse(valid_message.data.expect_response)
 
         # Test alternate msg_type
-        alt_message = NeonTtsResponse(data=data, message_id=message_id, context={}, 
+        alt_message = NeonTtsResponse(data=data, message_id=message_id, context={},
                                     msg_type="klat.response")
         self.assertEqual(alt_message.msg_type, "klat.response")
+
+        # Test `expect_response` flag is forwarded to signal clients to listen
+        listen_data = TtsReponseData(responses={"en-us": response},
+                                      expect_response=True)
+        listen_message = NeonTtsResponse(data=listen_data, context={},
+                                          msg_type="klat.response")
+        self.assertTrue(listen_message.data.expect_response)
 
         # Test missing required fields
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
# Description

Follow-up to NeonGeckoCom/neon_audio#198, per Daniel's review note: `klat.response` messages now forward `expect_response` (mapped from `listen`) so remote clients (e.g. hana's Node WebSocket) know to re-open the mic after TTS playback. `TtsReponseData`, which backs both `neon.get_tts.response` and `klat.response` via `NeonTtsResponse`, didn't have a field for it.

Adds `expect_response: bool = False` to `TtsReponseData`.

# Issues

Related: NeonGeckoCom/neon_audio#198

# Other Notes

Extended `test_neon_tts_response` to cover the default value and the `klat.response` case with `expect_response=True`.